### PR TITLE
feat(security): add sender allowlist, rate limiting, and pattern filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# TinyClaw Security Config
+#
+# Comma-separated phone numbers that can message the bot
+# Include country code, no spaces, no dashes, no plus sign
+# Example: US number (415) 555-1234 becomes 14155551234
+#
+TINYCLAW_ALLOWED_SENDERS=14155551234,14155555678

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Environment (contains phone numbers)
+.env
+
 # Dependencies
 node_modules/
 

--- a/.tinyclaw/config.json
+++ b/.tinyclaw/config.json
@@ -1,0 +1,9 @@
+{
+  "allowlistEnabled": true,
+  "rateLimitEnabled": true,
+  "rateLimit": {
+    "maxMessages": 10,
+    "windowMs": 60000
+  },
+  "patternFilterEnabled": true
+}

--- a/README.md
+++ b/README.md
@@ -61,10 +61,15 @@ Other Channels ──────┘        ↓
 ### Installation
 
 ```bash
-cd /Users/jliao/workspace/tinyclaw
+git clone https://github.com/jlia0/tinyclaw.git
+cd tinyclaw
 
 # Install dependencies
 npm install
+
+# Configure allowed senders (REQUIRED for security)
+cp .env.example .env
+# Edit .env and add your phone number(s)
 
 # Make scripts executable
 chmod +x *.sh *.js
@@ -312,10 +317,64 @@ WhatsApp session persists across restarts:
 
 ## 🔐 Security
 
+### Sender Allowlist
+
+Only specified phone numbers can trigger Claude. Set via environment variable:
+
+```bash
+# .env (gitignored)
+TINYCLAW_ALLOWED_SENDERS=14155551234,14155555678
+```
+
+Copy `.env.example` to `.env` and add your phone number(s).
+
+### Dangerous Pattern Filter (Optional)
+
+Defense-in-depth layer that blocks messages containing dangerous patterns before reaching Claude:
+- `rm -rf`, `sudo`, shell pipes (`| bash`)
+- SSH keys, `.env`, passwords, API keys, credentials
+- Destructive commands (`mkfs`, `dd if=`, `chmod 777`)
+
+**Enabled by default.** Disable if too aggressive for your use case:
+```json
+{ "patternFilterEnabled": false }
+```
+
+### Rate Limiting
+
+Prevents message flooding. Defaults: 10 messages per 60 seconds per sender.
+Includes helpful "wait X seconds" feedback when triggered.
+
+Configure in `.tinyclaw/config.json`:
+```json
+{
+  "rateLimitEnabled": true,
+  "rateLimit": { "maxMessages": 10, "windowMs": 60000 }
+}
+```
+
+### Full Configuration Example
+
+`.tinyclaw/config.json`:
+```json
+{
+  "allowlistEnabled": true,
+  "rateLimitEnabled": true,
+  "rateLimit": { "maxMessages": 10, "windowMs": 60000 },
+  "patternFilterEnabled": true
+}
+```
+
+### Other Protections
+
 - WhatsApp session stored locally in `.tinyclaw/whatsapp-session/`
 - Queue files are local (no network exposure)
 - Each channel handles its own authentication
 - Claude runs with your user permissions
+
+### ⚠️ Important Note
+
+This project uses `--dangerously-skip-permissions` which bypasses Claude's permission system. The security measures above reduce risk but cannot fully prevent a determined attacker with allowlist access from crafting malicious prompts.
 
 ## 🐛 Troubleshooting
 


### PR DESCRIPTION
## Summary

Security hardening following [OWASP AI Agent Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html) best practices:

- **Sender allowlist** via `TINYCLAW_ALLOWED_SENDERS` env var — only specified phone numbers can trigger Claude (primary defense)
- **Rate limiting** with helpful "wait X seconds" feedback — 10 messages per minute default, configurable
- **Dangerous pattern filter** — blocks `rm -rf`, `sudo`, credentials, SSH keys, etc before they reach Claude (optional, defense in depth)
- **Configurable** — all features can be toggled in `.tinyclaw/config.json`

## Why This Matters

The `--dangerously-skip-permissions` flag means anyone who can message your WhatsApp could potentially run arbitrary commands. These security layers significantly reduce that attack surface.

## Changes

| File | Changes |
|------|---------|
| `.env.example` | New — template for allowed phone numbers |
| `.tinyclaw/config.json` | New — security settings |
| `.gitignore` | Added `.env` |
| `whatsapp-client.js` | Allowlist check + rate limiting |
| `queue-processor.js` | Pattern filter (optional) |
| `README.md` | Full security documentation |

## Setup

```bash
cp .env.example .env
# Edit .env and add your phone number(s)
```

## Test Plan

- [ ] Send message from allowlisted number → works
- [ ] Send message from non-allowlisted number → blocked with log
- [ ] Send 11+ messages in 1 minute → rate limited with wait time shown
- [ ] Send "rm -rf test" → blocked by pattern filter
- [ ] Set `patternFilterEnabled: false` → pattern filter bypassed