### PR TITLE
Fix QR code not displaying during WhatsApp setup

### DIFF
--- a/whatsapp-client.js
+++ b/whatsapp-client.js
@@ -60,6 +60,12 @@ client.on('qr', (qr) => {
     qrcode.generate(qr, { small: true });
     console.log('\n');
     log('INFO', 'Open WhatsApp → Settings → Linked Devices → Link a Device');
+
+    // Write QR code to file so tinyclaw.sh can display it directly
+    // (tmux pane capture is unreliable for wide Unicode QR codes)
+    qrcode.generate(qr, { small: true }, function(qrOutput) {
+        fs.writeFileSync(path.join(SCRIPT_DIR, '.tinyclaw/qr-code.txt'), qrOutput);
+    });
 });
 
 // Authentication success


### PR DESCRIPTION
## Summary
- Fixes the QR code not rendering when running `tinyclaw.sh start` for first-time WhatsApp authentication
- Root cause: `tmux capture-pane` was grabbing QR output from a narrow (~39 col) tmux pane, causing Unicode QR characters to wrap and become garbled
- The WhatsApp client now writes the QR code to a temp file (`.tinyclaw/qr-code.txt`) via the `qrcode-terminal` callback, and the shell script reads it directly with `cat` at full terminal width

## Changes
- **`whatsapp-client.js`**: Added a second `qrcode.generate()` call with a callback that writes QR output to a file
- **`tinyclaw.sh`**: Replaced `tmux capture-pane` + `grep` approach with polling for the QR file and displaying it via `cat`

Fixes #7

## Test plan
- [ ] Run `tinyclaw.sh stop` then delete `.tinyclaw/whatsapp-session/` to force a fresh QR flow
- [ ] Run `tinyclaw.sh start` and verify the QR code renders correctly in the terminal
- [ ] Scan the QR code with WhatsApp and confirm authentication completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)