### PR TITLE
feat: add chrome config option for browser automation

### DIFF
--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -28,10 +28,17 @@ agent_list() {
     echo "================="
     echo ""
 
-    jq -r '(.agents // {}) | to_entries[] | "\(.key)|\(.value.name)|\(.value.provider)|\(.value.model)|\(.value.working_directory)"' "$SETTINGS_FILE" 2>/dev/null | \
-    while IFS='|' read -r id name provider model workdir; do
+    jq -r '(.agents // {}) | to_entries[] | "\(.key)|\(.value.name)|\(.value.provider)|\(.value.model)|\(.value.working_directory)|\(.value.chrome // "null")"' "$SETTINGS_FILE" 2>/dev/null | \
+    while IFS='|' read -r id name provider model workdir chrome; do
         echo -e "  ${GREEN}@${id}${NC} - ${name}"
         echo "    Provider:  ${provider}/${model}"
+        if [ "$provider" = "anthropic" ]; then
+            if [ "$chrome" = "false" ]; then
+                echo "    Chrome:    disabled"
+            else
+                echo "    Chrome:    enabled"
+            fi
+        fi
         echo "    Directory: ${workdir}"
         echo ""
     done
@@ -135,6 +142,17 @@ agent_add() {
         esac
     fi
 
+    # Chrome browser automation (Anthropic only)
+    AGENT_CHROME="true"
+    if [ "$AGENT_PROVIDER" = "anthropic" ]; then
+        echo ""
+        read -rp "Enable Chrome browser automation? [Y/n]: " AGENT_CHROME_INPUT
+        if [[ "$AGENT_CHROME_INPUT" =~ ^[nN] ]]; then
+            AGENT_CHROME="false"
+        fi
+        echo -e "${GREEN}✓ Chrome: $AGENT_CHROME${NC}"
+    fi
+
     # Working directory - automatically set to agent directory
     AGENT_WORKDIR="$AGENTS_DIR/$AGENT_ID"
 
@@ -143,17 +161,33 @@ agent_add() {
 
     # Build the agent JSON object
     local agent_json
-    agent_json=$(jq -n \
-        --arg name "$AGENT_NAME" \
-        --arg provider "$AGENT_PROVIDER" \
-        --arg model "$AGENT_MODEL" \
-        --arg workdir "$AGENT_WORKDIR" \
-        '{
-            name: $name,
-            provider: $provider,
-            model: $model,
-            working_directory: $workdir
-        }')
+    if [ "$AGENT_PROVIDER" = "anthropic" ]; then
+        agent_json=$(jq -n \
+            --arg name "$AGENT_NAME" \
+            --arg provider "$AGENT_PROVIDER" \
+            --arg model "$AGENT_MODEL" \
+            --arg workdir "$AGENT_WORKDIR" \
+            --argjson chrome "$AGENT_CHROME" \
+            '{
+                name: $name,
+                provider: $provider,
+                model: $model,
+                working_directory: $workdir,
+                chrome: $chrome
+            }')
+    else
+        agent_json=$(jq -n \
+            --arg name "$AGENT_NAME" \
+            --arg provider "$AGENT_PROVIDER" \
+            --arg model "$AGENT_MODEL" \
+            --arg workdir "$AGENT_WORKDIR" \
+            '{
+                name: $name,
+                provider: $provider,
+                model: $model,
+                working_directory: $workdir
+            }')
+    fi
 
     # Ensure agents section exists and add the new agent
     jq --arg id "$AGENT_ID" --argjson agent "$agent_json" \

--- a/lib/messaging.sh
+++ b/lib/messaging.sh
@@ -9,7 +9,7 @@ send_message() {
     log "[$source] Sending: ${message:0:50}..."
 
     cd "$SCRIPT_DIR"
-    RESPONSE=$(claude --dangerously-skip-permissions -c -p "$message" 2>&1)
+    RESPONSE=$(claude --dangerously-skip-permissions --chrome -c -p "$message" 2>&1)
 
     echo "$RESPONSE"
 

--- a/lib/setup-wizard.sh
+++ b/lib/setup-wizard.sh
@@ -137,6 +137,17 @@ else
     echo ""
 fi
 
+# Chrome browser automation (Anthropic only)
+CHROME_ENABLED="true"
+if [ "$PROVIDER" = "anthropic" ]; then
+    read -rp "Enable Chrome browser automation? [Y/n]: " CHROME_INPUT
+    if [[ "$CHROME_INPUT" =~ ^[nN] ]]; then
+        CHROME_ENABLED="false"
+    fi
+    echo -e "${GREEN}✓ Chrome: $CHROME_ENABLED${NC}"
+    echo ""
+fi
+
 # Heartbeat interval
 echo "Heartbeat interval (seconds)?"
 echo -e "${YELLOW}(How often Claude checks in proactively)${NC}"
@@ -190,7 +201,11 @@ DEFAULT_AGENT_DIR="$WORKSPACE_PATH/$DEFAULT_AGENT_NAME"
 # Capitalize first letter of agent name (proper bash method)
 DEFAULT_AGENT_DISPLAY="$(tr '[:lower:]' '[:upper:]' <<< "${DEFAULT_AGENT_NAME:0:1}")${DEFAULT_AGENT_NAME:1}"
 AGENTS_JSON='"agents": {'
-AGENTS_JSON="$AGENTS_JSON \"$DEFAULT_AGENT_NAME\": { \"name\": \"$DEFAULT_AGENT_DISPLAY\", \"provider\": \"$PROVIDER\", \"model\": \"$MODEL\", \"working_directory\": \"$DEFAULT_AGENT_DIR\" }"
+if [ "$PROVIDER" = "anthropic" ]; then
+    AGENTS_JSON="$AGENTS_JSON \"$DEFAULT_AGENT_NAME\": { \"name\": \"$DEFAULT_AGENT_DISPLAY\", \"provider\": \"$PROVIDER\", \"model\": \"$MODEL\", \"working_directory\": \"$DEFAULT_AGENT_DIR\", \"chrome\": $CHROME_ENABLED }"
+else
+    AGENTS_JSON="$AGENTS_JSON \"$DEFAULT_AGENT_NAME\": { \"name\": \"$DEFAULT_AGENT_DISPLAY\", \"provider\": \"$PROVIDER\", \"model\": \"$MODEL\", \"working_directory\": \"$DEFAULT_AGENT_DIR\" }"
+fi
 
 ADDITIONAL_AGENTS=()  # Track additional agent IDs for directory creation
 
@@ -241,7 +256,21 @@ if [[ "$SETUP_AGENTS" =~ ^[yY] ]]; then
 
         NEW_AGENT_DIR="$WORKSPACE_PATH/$NEW_AGENT_ID"
 
-        AGENTS_JSON="$AGENTS_JSON, \"$NEW_AGENT_ID\": { \"name\": \"$NEW_AGENT_NAME\", \"provider\": \"$NEW_PROVIDER\", \"model\": \"$NEW_MODEL\", \"working_directory\": \"$NEW_AGENT_DIR\" }"
+        # Chrome browser automation (Anthropic only)
+        NEW_CHROME_ENABLED="true"
+        if [ "$NEW_PROVIDER" = "anthropic" ]; then
+            read -rp "  Enable Chrome browser automation? [Y/n]: " NEW_CHROME_INPUT
+            if [[ "$NEW_CHROME_INPUT" =~ ^[nN] ]]; then
+                NEW_CHROME_ENABLED="false"
+            fi
+            echo -e "  ${GREEN}✓ Chrome: $NEW_CHROME_ENABLED${NC}"
+        fi
+
+        if [ "$NEW_PROVIDER" = "anthropic" ]; then
+            AGENTS_JSON="$AGENTS_JSON, \"$NEW_AGENT_ID\": { \"name\": \"$NEW_AGENT_NAME\", \"provider\": \"$NEW_PROVIDER\", \"model\": \"$NEW_MODEL\", \"working_directory\": \"$NEW_AGENT_DIR\", \"chrome\": $NEW_CHROME_ENABLED }"
+        else
+            AGENTS_JSON="$AGENTS_JSON, \"$NEW_AGENT_ID\": { \"name\": \"$NEW_AGENT_NAME\", \"provider\": \"$NEW_PROVIDER\", \"model\": \"$NEW_MODEL\", \"working_directory\": \"$NEW_AGENT_DIR\" }"
+        fi
 
         # Track this agent for directory creation later
         ADDITIONAL_AGENTS+=("$NEW_AGENT_ID")

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -60,6 +60,7 @@ export function getDefaultAgentFromModels(settings: Settings): AgentConfig {
         provider,
         model,
         working_directory: defaultAgentDir,
+        ...(provider === 'anthropic' ? { chrome: true } : {}),
     };
 }
 

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -124,6 +124,9 @@ export async function invokeAgent(
 
         const modelId = resolveClaudeModel(agent.model);
         const claudeArgs = ['--dangerously-skip-permissions'];
+        if (agent.chrome !== false) {
+            claudeArgs.push('--chrome');
+        }
         if (modelId) {
             claudeArgs.push('--model', modelId);
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@ export interface AgentConfig {
     provider: string;       // 'anthropic' or 'openai'
     model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex'
     working_directory: string;
+    chrome?: boolean;  // Enable Chrome browser automation (Anthropic only, default: true)
 }
 
 export interface TeamConfig {

--- a/src/queue-processor.ts
+++ b/src/queue-processor.ts
@@ -458,7 +458,8 @@ function logAgentConfig(): void {
     const agentCount = Object.keys(agents).length;
     log('INFO', `Loaded ${agentCount} agent(s):`);
     for (const [id, agent] of Object.entries(agents)) {
-        log('INFO', `  ${id}: ${agent.name} [${agent.provider}/${agent.model}] cwd=${agent.working_directory}`);
+        const chromeStatus = agent.provider === 'anthropic' ? ` chrome=${agent.chrome !== false}` : '';
+        log('INFO', `  ${id}: ${agent.name} [${agent.provider}/${agent.model}]${chromeStatus} cwd=${agent.working_directory}`);
     }
 
     const teamCount = Object.keys(teams).length;


### PR DESCRIPTION

<img width="771" height="614" alt="Screenshot 2026-02-13 at 7 44 42 AM" src="https://github.com/user-attachments/assets/d2e4f749-2791-4247-9152-fa85735e791d" />
<img width="801" height="332" alt="Screenshot 2026-02-13 at 7 45 44 AM" src="https://github.com/user-attachments/assets/823e5dc4-aa8b-41b9-b76b-b4007648cdbf" />


## Summary

- Adds per-agent `chrome` boolean field to AgentConfig (Anthropic only, default: `true`)
- Passes `--chrome` to Claude Code CLI when enabled, allowing agents to use browser automation via the Claude in Chrome extension
- Only explicit `chrome: false` disables it; `undefined` and `true` both enable it
- OpenAI/Codex agents never get the field or the flag

## Changes

| File | Change |
|------|--------|
| `src/lib/types.ts` | Add `chrome?: boolean` to `AgentConfig` |
| `src/lib/invoke.ts` | Pass `--chrome` when `agent.chrome !== false` |
| `src/lib/config.ts` | Set `chrome: true` on default Anthropic agents |
| `lib/setup-wizard.sh` | Chrome prompt for Anthropic (default + additional agents) |
| `lib/agents.sh` | Chrome prompt in `agent_add()`, display in `agent_list()` |
| `src/queue-processor.ts` | Log chrome status on startup |
| `lib/messaging.sh` | Add `--chrome` to legacy invocation |
