### PR TITLE
fix: prevent queue processor deadlock from duplicate file queueing

### DIFF
--- a/src/queue-processor.ts
+++ b/src/queue-processor.ts
@@ -29,6 +29,19 @@ import { invokeAgent } from './lib/invoke';
     }
 });
 
+// Files currently queued in a promise chain — prevents duplicate processing across ticks
+const queuedFiles = new Set<string>();
+
+// Recover orphaned files from processing/ on startup (crash recovery)
+function recoverOrphanedFiles() {
+    for (const f of fs.readdirSync(QUEUE_PROCESSING).filter(f => f.endsWith('.json'))) {
+        try {
+            fs.renameSync(path.join(QUEUE_PROCESSING, f), path.join(QUEUE_INCOMING, f));
+            log('INFO', `Recovered orphaned file: ${f}`);
+        } catch {}
+    }
+}
+
 // Process a single message
 async function processMessage(messageFile: string): Promise<void> {
     const processingFile = path.join(QUEUE_PROCESSING, path.basename(messageFile));
@@ -420,6 +433,10 @@ async function processQueue(): Promise<void> {
 
             // Process messages in parallel by agent (sequential within each agent)
             for (const file of files) {
+                // Skip files already queued in a promise chain
+                if (queuedFiles.has(file.name)) continue;
+                queuedFiles.add(file.name);
+
                 // Determine target agent
                 const agentId = peekAgentId(file.path);
 
@@ -431,6 +448,9 @@ async function processQueue(): Promise<void> {
                     .then(() => processMessage(file.path))
                     .catch(error => {
                         log('ERROR', `Error processing message for agent ${agentId}: ${error.message}`);
+                    })
+                    .finally(() => {
+                        queuedFiles.delete(file.name);
                     });
 
                 // Update the chain
@@ -477,6 +497,7 @@ if (!fs.existsSync(EVENTS_DIR)) {
 
 // Main loop
 log('INFO', 'Queue processor started');
+recoverOrphanedFiles();
 log('INFO', `Watching: ${QUEUE_INCOMING}`);
 logAgentConfig();
 emitEvent('processor_start', { agents: Object.keys(getAgents(getSettings())), teams: Object.keys(getTeams(getSettings())) });


### PR DESCRIPTION
## Summary

Fixes #37 — the queue processor enters a deadlock state under rapid messaging because the same file gets queued multiple times in the per-agent promise chain.

## Root Cause

The `setInterval` timer re-reads `incoming/` every 1 second. Files waiting in the promise chain (not yet moved to `processing/`) are still in `incoming/`, so they get queued again on each tick. Under rapid messaging with 15-30s API response times, a single file can accumulate 20+ duplicate entries in the chain.

When duplicates execute, the first succeeds but subsequent copies fail with `ENOENT` (file already moved). If the API also fails and moves the file back to `incoming/`, duplicates retry it too — creating a snowball where the chain grows faster than it can drain, blocking all new messages.

## Changes

**`src/queue-processor.ts`** (21 lines added, 0 deleted):

- **`queuedFiles` Set**: Tracks files currently in a promise chain. `processQueue` skips files already in the Set. `.finally()` removes them when processing completes (success or failure), allowing clean single retries.
- **`recoverOrphanedFiles()`**: On startup, moves any files stuck in `processing/` back to `incoming/` — handles the case where the process was killed mid-processing.

## Test Plan

- [ ] Send 5+ rapid messages on Telegram — verify no `ENOENT` errors in queue log
- [ ] Kill queue processor mid-processing, restart — verify orphaned files are recovered
- [ ] Verify normal single-message flow still works
- [ ] Verify multi-agent routing still works

cc @arunsathiya