### PR TITLE
Harden channel auth, file safety, and update integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
           BUNDLE_NAME="tinyclaw-bundle.tar.gz"
+          CHECKSUM_NAME="tinyclaw-bundle.sha256"
           TEMP_DIR=$(mktemp -d)
           BUNDLE_DIR="$TEMP_DIR/tinyclaw"
 
@@ -89,11 +90,17 @@ jobs:
           # Create tarball
           cd "$TEMP_DIR"
           tar -czf "$GITHUB_WORKSPACE/$BUNDLE_NAME" tinyclaw/
+          if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "$GITHUB_WORKSPACE/$BUNDLE_NAME" | awk '{print $1}' > "$GITHUB_WORKSPACE/$CHECKSUM_NAME"
+          else
+            sha256sum "$GITHUB_WORKSPACE/$BUNDLE_NAME" | awk '{print $1}' > "$GITHUB_WORKSPACE/$CHECKSUM_NAME"
+          fi
 
           # Get bundle info
           BUNDLE_SIZE=$(du -h "$GITHUB_WORKSPACE/$BUNDLE_NAME" | cut -f1)
           echo "Bundle created: $BUNDLE_NAME ($BUNDLE_SIZE)"
           echo "bundle_name=$BUNDLE_NAME" >> $GITHUB_OUTPUT
+          echo "checksum_name=$CHECKSUM_NAME" >> $GITHUB_OUTPUT
           echo "bundle_size=$BUNDLE_SIZE" >> $GITHUB_OUTPUT
 
       - name: Generate release notes
@@ -138,6 +145,7 @@ jobs:
           body_path: release_notes.md
           files: |
             tinyclaw-bundle.tar.gz
+            tinyclaw-bundle.sha256
           draft: false
           prerelease: false
         env:
@@ -148,5 +156,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tinyclaw-bundle
-          path: tinyclaw-bundle.tar.gz
+          path: |
+            tinyclaw-bundle.tar.gz
+            tinyclaw-bundle.sha256
           retention-days: 7

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Run multiple teams of AI agents that collaborate with each other simultaneously 
 - Node.js v14+
 - tmux
 - Bash 4.0+ (macOS: `brew install bash`)
+- jq (`brew install jq` or `apt install jq`)
 - [Claude Code CLI](https://claude.com/claude-code) (for Anthropic provider)
 - [Codex CLI](https://docs.openai.com/codex) (for OpenAI provider)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -9,7 +9,7 @@ curl -fsSL https://raw.githubusercontent.com/jlia0/tinyclaw/main/scripts/remote-
 ```
 
 This one-line command:
-- ✅ Checks all dependencies (node, npm, tmux, claude)
+- ✅ Checks all dependencies (node, npm, tmux, claude, jq)
 - ✅ Downloads pre-built bundle (no npm install needed!)
 - ✅ Installs to `~/.tinyclaw`
 - ✅ Creates global `tinyclaw` command
@@ -28,6 +28,7 @@ Before installing, ensure you have:
 - **npm** (comes with Node.js)
 - **tmux** - `sudo apt install tmux` or `brew install tmux`
 - **Claude Code CLI** ([claude.com/claude-code](https://claude.com/claude-code))
+- **jq** - `sudo apt install jq` or `brew install jq`
 
 **Optional:**
 - **git** (only needed for source install)
@@ -191,6 +192,10 @@ brew install tmux            # macOS
 
 # Claude Code
 # Visit: https://claude.com/claude-code
+
+# jq
+sudo apt install jq          # Ubuntu/Debian
+brew install jq              # macOS
 ```
 
 ### Bundle download fails

--- a/lib/messaging.sh
+++ b/lib/messaging.sh
@@ -9,7 +9,12 @@ send_message() {
     log "[$source] Sending: ${message:0:50}..."
 
     cd "$SCRIPT_DIR"
-    RESPONSE=$(claude --dangerously-skip-permissions -c -p "$message" 2>&1)
+    local claude_cmd=(claude -c -p "$message")
+    if [ "${TINYCLAW_ALLOW_DANGEROUS_FLAGS:-0}" = "1" ]; then
+        claude_cmd=(claude --dangerously-skip-permissions -c -p "$message")
+        log "[$source] WARNING: dangerous permissions flag enabled via TINYCLAW_ALLOW_DANGEROUS_FLAGS=1"
+    fi
+    RESPONSE=$("${claude_cmd[@]}" 2>&1)
 
     echo "$RESPONSE"
 

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -33,6 +33,7 @@ if [ -n "$GIT_TAG" ]; then
 fi
 
 BUNDLE_NAME="tinyclaw-bundle-${VERSION}.tar.gz"
+CHECKSUM_NAME="tinyclaw-bundle-${VERSION}.sha256"
 TEMP_DIR=$(mktemp -d)
 BUNDLE_DIR="$TEMP_DIR/tinyclaw"
 
@@ -113,6 +114,15 @@ cd "$SCRIPT_DIR"
 rm -rf "$TEMP_DIR"
 
 BUNDLE_SIZE=$(du -h "$BUNDLE_NAME" | cut -f1)
+
+if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$BUNDLE_NAME" | awk '{print $1}' > "$CHECKSUM_NAME"
+elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$BUNDLE_NAME" | awk '{print $1}' > "$CHECKSUM_NAME"
+else
+    echo -e "${YELLOW}⚠ Could not generate checksum (missing shasum/sha256sum)${NC}"
+fi
+
 echo -e "${GREEN}✓ Bundle created: $BUNDLE_NAME ($BUNDLE_SIZE)${NC}"
 echo ""
 

--- a/src/channels/telegram-client.ts
+++ b/src/channels/telegram-client.ts
@@ -105,11 +105,34 @@ function pathInDirectory(candidatePath: string, directoryPath: string): boolean 
     }
 }
 
+function readSecuritySettings(): {
+    requireSenderAllowlist: boolean;
+    allowOutsideFilesDir: boolean;
+    allowedSenders: string[];
+} {
+    try {
+        const settingsData = fs.readFileSync(SETTINGS_FILE, 'utf8');
+        const settings = JSON.parse(settingsData);
+        return {
+            requireSenderAllowlist: settings?.security?.require_sender_allowlist !== false,
+            allowOutsideFilesDir: settings?.security?.allow_outbound_file_paths_outside_files_dir === true,
+            allowedSenders: settings?.security?.allowed_senders?.telegram || [],
+        };
+    } catch {
+        return {
+            requireSenderAllowlist: true,
+            allowOutsideFilesDir: false,
+            allowedSenders: [],
+        };
+    }
+}
+
 function isAllowedOutgoingFile(filePath: string): boolean {
     if (!fs.existsSync(filePath)) return false;
     const stat = fs.statSync(filePath);
     if (!stat.isFile()) return false;
-    return pathInDirectory(filePath, FILES_DIR);
+    const security = readSecuritySettings();
+    return security.allowOutsideFilesDir || pathInDirectory(filePath, FILES_DIR);
 }
 
 // Track pending messages (waiting for response)
@@ -171,16 +194,9 @@ function getAgentListText(): string {
 }
 
 function isSenderAllowed(senderId: string): boolean {
-    try {
-        const settingsData = fs.readFileSync(SETTINGS_FILE, 'utf8');
-        const settings = JSON.parse(settingsData);
-        const requireAllowlist = settings?.security?.require_sender_allowlist !== false;
-        if (!requireAllowlist) return true;
-        const allowed: string[] = settings?.security?.allowed_senders?.telegram || [];
-        return allowed.includes('*') || allowed.includes(senderId);
-    } catch {
-        return false;
-    }
+    const security = readSecuritySettings();
+    if (!security.requireSenderAllowlist) return true;
+    return security.allowedSenders.includes('*') || security.allowedSenders.includes(senderId);
 }
 
 // Split long messages for Telegram's 4096 char limit

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,6 +15,7 @@ export const RESET_FLAG = path.join(TINYCLAW_HOME, 'reset_flag');
 export const SETTINGS_FILE = path.join(TINYCLAW_HOME, 'settings.json');
 export const EVENTS_DIR = path.join(TINYCLAW_HOME, 'events');
 export const CHATS_DIR = path.join(TINYCLAW_HOME, 'chats');
+export const FILES_DIR = path.join(TINYCLAW_HOME, 'files');
 
 export function getSettings(): Settings {
     try {

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -54,7 +54,8 @@ export async function invokeAgent(
     workspacePath: string,
     shouldReset: boolean,
     agents: Record<string, AgentConfig> = {},
-    teams: Record<string, TeamConfig> = {}
+    teams: Record<string, TeamConfig> = {},
+    allowDangerousFlags = false
 ): Promise<string> {
     // Ensure agent directory exists with config files
     const agentDir = path.join(workspacePath, agentId);
@@ -93,7 +94,12 @@ export async function invokeAgent(
         if (modelId) {
             codexArgs.push('--model', modelId);
         }
-        codexArgs.push('--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', '--json', message);
+        codexArgs.push('--skip-git-repo-check');
+        if (allowDangerousFlags) {
+            codexArgs.push('--dangerously-bypass-approvals-and-sandbox');
+            log('WARN', `Dangerous Codex flags enabled for agent: ${agentId}`);
+        }
+        codexArgs.push('--json', message);
 
         const codexOutput = await runCommand('codex', codexArgs, workingDir);
 
@@ -123,7 +129,11 @@ export async function invokeAgent(
         }
 
         const modelId = resolveClaudeModel(agent.model);
-        const claudeArgs = ['--dangerously-skip-permissions'];
+        const claudeArgs: string[] = [];
+        if (allowDangerousFlags) {
+            claudeArgs.push('--dangerously-skip-permissions');
+            log('WARN', `Dangerous Claude flags enabled for agent: ${agentId}`);
+        }
         if (modelId) {
             claudeArgs.push('--model', modelId);
         }

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -2,6 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import { LOG_FILE, EVENTS_DIR } from './config';
 
+const EVENT_RETENTION_MS = Number(process.env.TINYCLAW_EVENT_RETENTION_MS || (24 * 60 * 60 * 1000));
+let lastEventCleanup = 0;
+
 export function log(level: string, message: string): void {
     const timestamp = new Date().toISOString();
     const logMessage = `[${timestamp}] [${level}] ${message}\n`;
@@ -17,6 +20,22 @@ export function emitEvent(type: string, data: Record<string, unknown>): void {
     try {
         if (!fs.existsSync(EVENTS_DIR)) {
             fs.mkdirSync(EVENTS_DIR, { recursive: true });
+        }
+        const now = Date.now();
+        if (now - lastEventCleanup > 60_000) {
+            lastEventCleanup = now;
+            const files = fs.readdirSync(EVENTS_DIR).filter(f => f.endsWith('.json'));
+            for (const file of files) {
+                const filePath = path.join(EVENTS_DIR, file);
+                try {
+                    const stat = fs.statSync(filePath);
+                    if (now - stat.mtimeMs > EVENT_RETENTION_MS) {
+                        fs.unlinkSync(filePath);
+                    }
+                } catch {
+                    // Best-effort cleanup only.
+                }
+            }
         }
         const event = { type, timestamp: Date.now(), ...data };
         const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.json`;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,17 @@ export interface Settings {
     monitoring?: {
         heartbeat_interval?: number;
     };
+    security?: {
+        require_sender_allowlist?: boolean;
+        allowed_senders?: {
+            discord?: string[];
+            telegram?: string[];
+            whatsapp?: string[];
+        };
+        allow_dangerous_agent_flags?: boolean;
+        allow_outbound_file_paths_outside_files_dir?: boolean;
+        persist_team_chats?: boolean;
+    };
 }
 
 export interface MessageData {


### PR DESCRIPTION
## Summary
This PR fixes the full security/code-review audit set by hardening chat ingress, agent invocation, outbound file handling, and bundle update/install integrity.

## What changed
- Enforce sender allowlists (default-on) across Telegram, Discord, WhatsApp, and queue processing.
- Restrict outbound `[send_file: ...]` paths to `.tinyclaw/files` by default (realpath checks + defense in depth).
- Gate dangerous CLI flags behind explicit config/env opt-in (`allow_dangerous_agent_flags`, `TINYCLAW_ALLOW_DANGEROUS_FLAGS`).
- Add attachment download guards (size limits, timeouts, redirects, status checks).
- Add SHA-256 checksum verification to update/install flows and publish checksum in release workflow.
- Fix stale build detection by checking all TypeScript sources via a build stamp.
- Rework setup JSON generation to use `jq` safely (no raw interpolation) and add security prompts/defaults.
- Reduce sensitive persistence in events/logging and make full team chat persistence opt-in.

## Validation
- `bash -n` passed for modified shell scripts.
- `npm run build` passed.

## Notes
- Default behavior now requires allowlisted sender IDs in settings; unknown senders are denied until configured.
