### PR TITLE
feat: register Telegram bot commands on startup

### DIFF
--- a/src/channels/telegram-client.ts
+++ b/src/channels/telegram-client.ts
@@ -258,8 +258,16 @@ function pairingMessage(code: string): string {
 const bot = new TelegramBot(TELEGRAM_BOT_TOKEN, { polling: true });
 
 // Bot ready
-bot.getMe().then((me: TelegramBot.User) => {
+bot.getMe().then(async (me: TelegramBot.User) => {
     log('INFO', `Telegram bot connected as @${me.username}`);
+
+    // Register bot commands so they appear in Telegram's "/" menu
+    await bot.setMyCommands([
+        { command: 'agent', description: 'List available agents' },
+        { command: 'team', description: 'List available teams' },
+        { command: 'reset', description: 'Reset conversation history' },
+    ]).catch((err: Error) => log('WARN', `Failed to register commands: ${err.message}`));
+
     log('INFO', 'Listening for messages...');
 }).catch((err: Error) => {
     log('ERROR', `Failed to connect: ${err.message}`);


### PR DESCRIPTION
## Summary
- TinyClaw handles `/agent`, `/team`, and `/reset` commands but never calls `setMyCommands`, so they don't appear in Telegram's "/" command menu
- Adds a `setMyCommands` call right after the bot connects, registering all three commands automatically

## Test plan
- [ ] Start tinyclaw, open Telegram, type "/" — commands should appear in autocomplete
- [ ] Verify `/agent`, `/team`, `/reset` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)