### PR TITLE
Add per-agent Telegram bot support

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,9 @@ export interface AgentConfig {
     provider: string;       // 'anthropic' or 'openai'
     model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex'
     working_directory: string;
+    telegram?: {
+        bot_token?: string; // optional: dedicated bot token for this agent
+    };
 }
 
 export interface TeamConfig {


### PR DESCRIPTION
This PR adds support for dedicated Telegram bots per agent, allowing users to have separate 1:1 chats with each agent without needing to use @agent tags.

Features:
- Agents can optionally have their own Telegram bot via telegram.bot_token
- Multiple bot instances run simultaneously (main + agent-specific)
- Main bot continues to support @agent routing for group chats
- Agent-specific bots auto-route messages to their agent (no tagging)
- Setup wizard prompts for bot token when adding new agents

Implementation:
- Added telegram.bot_token field to AgentConfig (nested format)
- Refactored telegram-client.ts to support multiple bot instances
- Track which bot should handle each response via botKey field
- Proper typing indicators and response routing per bot
- Interactive setup in 'tinyclaw agent add' command

Benefits:
- Better UX: Direct chat with specific agents
- Organization: Separate threads for different purposes
- Flexibility: Optional feature, falls back to main bot
- Backward compatible: Existing configs work unchanged

Configuration example:
{
  "agents": { "support": { "telegram": { "bot_token": "SUPPORT_BOT_TOKEN" } } } }