### PR TITLE
Add optional OpenAI-compatible endpoint support per agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ The setup wizard will guide you through:
 3. **Workspace setup** - Name your workspace directory
 4. **Default agent** - Configure your main AI assistant
 5. **AI provider** - Select Anthropic (Claude) or OpenAI
-6. **Model selection** - Choose model (e.g., Sonnet, Opus, GPT-5.3)
-7. **Heartbeat interval** - Set proactive check-in frequency
+6. **Model selection** - Choose model (e.g., Sonnet, Opus, GPT-5.3, or custom OpenAI-compatible model)
+7. **OpenAI endpoint (optional)** - Set custom OpenAI-compatible `base_url` and `api_key`
+8. **Heartbeat interval** - Set proactive check-in frequency
 
 <details>
 <summary><b>📱 Channel Setup Guides</b></summary>
@@ -277,7 +278,11 @@ Agents are configured in `.tinyclaw/settings.json`:
       "name": "Technical Writer",
       "provider": "openai",
       "model": "gpt-5.3-codex",
-      "working_directory": "/Users/me/tinyclaw-workspace/writer"
+      "working_directory": "/Users/me/tinyclaw-workspace/writer",
+      "openai": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "your-api-key"
+      }
     }
   }
 }
@@ -289,6 +294,7 @@ Each agent operates in isolation:
 - **Own conversation history** - Maintained by CLI
 - **Custom configuration** - `.claude/`, `heartbeat.md` (root), `AGENTS.md`
 - **Independent resets** - Reset individual agent conversations
+- **Optional OpenAI-compatible endpoints** - Set `openai.base_url`/`openai.api_key` per OpenAI agent
 
 <details>
 <summary><b>📖 Learn more about agents</b></summary>
@@ -427,6 +433,21 @@ Located at `.tinyclaw/settings.json`:
   },
   "monitoring": {
     "heartbeat_interval": 3600
+  }
+}
+```
+
+For OpenAI-compatible providers, you can also configure endpoint defaults in `models.openai` (applies to default/fallback agent and as defaults for OpenAI agents):
+
+```json
+{
+  "models": {
+    "provider": "openai",
+    "openai": {
+      "model": "gpt-5.3-codex",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key": "your-api-key"
+    }
   }
 }
 ```

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -97,6 +97,10 @@ Each agent has its own configuration in `.tinyclaw/settings.json`:
       "provider": "openai",
       "model": "gpt-5.3-codex",
       "working_directory": "/Users/me/tinyclaw-workspace/writer",
+      "openai": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "your-api-key"
+      },
       "prompt_file": "/path/to/writer-prompt.md"
     },
     "assistant": {
@@ -182,6 +186,8 @@ claude --dangerously-skip-permissions \
 **OpenAI (Codex):**
 ```bash
 cd "$agent_working_directory"  # e.g., ~/tinyclaw-workspace/coder/
+OPENAI_BASE_URL="https://openrouter.ai/api/v1" \
+OPENAI_API_KEY="your-api-key" \
 codex exec resume --last \
   --model gpt-5.3-codex \
   --skip-git-repo-check \
@@ -189,6 +195,7 @@ codex exec resume --last \
   --json \
   "User message here"
 ```
+`OPENAI_BASE_URL` and `OPENAI_API_KEY` are optional and only used when configured.
 
 ## Configuration
 
@@ -215,8 +222,8 @@ This walks you through:
 1. Agent ID (e.g., `coder`)
 2. Display name (e.g., `Code Assistant`)
 3. Provider (Anthropic or OpenAI)
-4. Model selection
-5. Optional system prompt
+4. Model selection (including custom OpenAI-compatible model names)
+5. Optional OpenAI-compatible endpoint settings (`base_url`, `api_key`) for OpenAI agents
 
 **Working directory is automatically set to:** `<workspace>/<agent_id>/`
 
@@ -250,6 +257,8 @@ Edit `.tinyclaw/settings.json`:
 | `provider` | Yes | `anthropic` or `openai` |
 | `model` | Yes | Model identifier (e.g., `sonnet`, `opus`, `gpt-5.3-codex`) |
 | `working_directory` | Yes | Directory where agent operates (auto-set to `<workspace>/<agent_id>/`) |
+| `openai.base_url` | No | Optional OpenAI-compatible endpoint base URL for OpenAI agents |
+| `openai.api_key` | No | Optional API key exported as `OPENAI_API_KEY` for OpenAI agents |
 | `system_prompt` | No | Inline system prompt text |
 | `prompt_file` | No | Path to file containing system prompt |
 
@@ -428,9 +437,11 @@ If no agents are configured, TinyClaw automatically creates a default agent usin
 ```json
 {
   "models": {
-    "provider": "anthropic",
-    "anthropic": {
-      "model": "sonnet"
+    "provider": "openai",
+    "openai": {
+      "model": "gpt-5.3-codex",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key": "your-api-key"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyclaw",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyclaw",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "@types/react": "^19.2.14",
         "discord.js": "^14.16.0",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,10 @@ export interface AgentConfig {
     provider: string;       // 'anthropic' or 'openai'
     model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex'
     working_directory: string;
+    openai?: {
+        base_url?: string;
+        api_key?: string;
+    };
 }
 
 export interface TeamConfig {
@@ -34,6 +38,8 @@ export interface Settings {
         };
         openai?: {
             model?: string;
+            base_url?: string;
+            api_key?: string;
         };
     };
     agents?: Record<string, AgentConfig>;


### PR DESCRIPTION
## Summary\n- add optional openai.base_url and openai.api_key settings for OpenAI agents\n- apply global models.openai endpoint defaults to OpenAI agents while allowing per-agent overrides\n- export endpoint/key env vars when invoking Codex (OPENAI_BASE_URL, OPENAI_API_BASE, OPENAI_API_KEY)\n- extend setup flows (	inyclaw setup, 	inyclaw agent add) to support custom OpenAI-compatible model names and optional endpoint/key input\n- document the new config options in README and AGENTS docs\n\n## Validation\n- ash -n lib/setup-wizard.sh\n- ash -n lib/agents.sh\n- 
pm run build\n\nCloses #41.