### PR TITLE
Improve PATH configuration for ~/.local/bin installations

### DIFF
--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -181,10 +181,45 @@ chmod +x lib/setup-wizard.sh
 chmod +x lib/heartbeat-cron.sh
 chmod +x lib/update.sh
 
-# Run the install script (suppress its output — we show our own)
+# Run the install script (creates symlink and configures PATH)
 "$INSTALL_DIR/scripts/install.sh" > /dev/null 2>&1
 
 echo -e "${GREEN}✓ CLI command installed${NC}"
+
+# Detect shell profile and ensure ~/.local/bin is in PATH
+# (install.sh may have already written to the profile, but this ensures
+# the remote-install output gives the user the right guidance)
+NEED_RESTART=false
+
+if ! command -v tinyclaw &> /dev/null; then
+    # Check if the symlink landed in ~/.local/bin
+    if [ -L "$HOME/.local/bin/tinyclaw" ]; then
+        SHELL_NAME="$(basename "$SHELL")"
+        case "$SHELL_NAME" in
+            zsh)  SHELL_PROFILE="$HOME/.zshrc" ;;
+            bash)
+                if [ -f "$HOME/.bash_profile" ]; then
+                    SHELL_PROFILE="$HOME/.bash_profile"
+                else
+                    SHELL_PROFILE="$HOME/.bashrc"
+                fi
+                ;;
+            *)    SHELL_PROFILE="$HOME/.profile" ;;
+        esac
+
+        PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+
+        # Add to profile if not already present
+        if [ -n "$SHELL_PROFILE" ] && ! grep -qF '.local/bin' "$SHELL_PROFILE" 2>/dev/null; then
+            echo "" >> "$SHELL_PROFILE"
+            echo "# Added by TinyClaw installer" >> "$SHELL_PROFILE"
+            echo "$PATH_LINE" >> "$SHELL_PROFILE"
+            echo -e "${GREEN}✓ Added ~/.local/bin to PATH in ${SHELL_PROFILE/#$HOME/\~}${NC}"
+        fi
+
+        NEED_RESTART=true
+    fi
+fi
 
 echo ""
 echo -e "${GREEN}╔════════════════════════════════════════╗${NC}"
@@ -193,6 +228,12 @@ echo -e "${GREEN}╚════════════════════
 echo ""
 echo -e "Installation directory: ${BLUE}$INSTALL_DIR${NC}"
 echo ""
+
+if [ "$NEED_RESTART" = true ]; then
+    echo -e "${YELLOW}Important: Restart your terminal (or run 'source ${SHELL_PROFILE/#$HOME/\~}') to use the 'tinyclaw' command.${NC}"
+    echo ""
+fi
+
 echo "Next steps:"
 echo ""
 echo -e "  ${GREEN}1.${NC} Start TinyClaw:"


### PR DESCRIPTION
## Summary
This PR improves the user experience when installing TinyClaw to `~/.local/bin` by automatically detecting the user's shell and adding the directory to their PATH configuration, rather than just displaying instructions.

## Key Changes

- **Automatic PATH configuration**: Instead of just warning users that `~/.local/bin` is not in PATH, the installer now automatically detects the user's shell (bash, zsh, or other) and adds the appropriate PATH export to their shell profile (`~/.bashrc`, `~/.bash_profile`, `~/.zshrc`, or `~/.profile`).

- **Smart shell detection**: Implements proper shell detection logic that handles bash's preference for `~/.bash_profile` over `~/.bashrc` when available, and falls back to `~/.profile` for other shells.

- **Duplicate prevention**: Checks if `~/.local/bin` is already in the shell profile before adding it, preventing duplicate entries on repeated installations.

- **Current session PATH update**: Exports the PATH in the current session so the command may work immediately without requiring a terminal restart.

- **Consistent behavior across installers**: Both `install.sh` and `remote-install.sh` now implement the same PATH configuration logic, with `remote-install.sh` providing additional guidance to the user about whether a restart is needed.

- **Improved user messaging**: Replaces generic instructions with specific, actionable feedback that tells users exactly which file was modified and what command to run if they need to reload their shell immediately.

## Implementation Details

- The PATH line is added with a comment marker (`# Added by TinyClaw installer`) for clarity
- Uses `grep -qF` to safely check for existing `.local/bin` entries without regex interpretation
- Handles edge cases like missing shell profile files gracefully
- Provides shell-specific guidance (e.g., `source ~/.zshrc` vs `source ~/.bashrc`)

https://claude.ai/code/session_01SFAXrKTV5Lfj4f7NDZLiTb