### PR TITLE
Add agent provider and model management command

### DIFF
--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -299,6 +299,99 @@ agent_remove() {
     echo -e "${GREEN}✓ Agent '${agent_id}' removed.${NC}"
 }
 
+# Set provider and/or model for a specific agent
+agent_provider() {
+    local agent_id="$1"
+    local provider_arg="$2"
+    local model_arg=""
+
+    # Parse optional --model flag
+    if [ "$3" = "--model" ] && [ -n "$4" ]; then
+        model_arg="$4"
+    fi
+
+    if [ ! -f "$SETTINGS_FILE" ]; then
+        echo -e "${RED}No settings file found.${NC}"
+        exit 1
+    fi
+
+    local agent_json
+    agent_json=$(jq -r "(.agents // {}).\"${agent_id}\" // empty" "$SETTINGS_FILE" 2>/dev/null)
+
+    if [ -z "$agent_json" ]; then
+        echo -e "${RED}Agent '${agent_id}' not found.${NC}"
+        echo ""
+        echo "Available agents:"
+        jq -r '(.agents // {}) | keys[]' "$SETTINGS_FILE" 2>/dev/null | while read -r id; do
+            echo "  @${id}"
+        done
+        exit 1
+    fi
+
+    if [ -z "$provider_arg" ]; then
+        # Show current provider/model for this agent
+        local cur_provider cur_model agent_name
+        cur_provider=$(jq -r "(.agents // {}).\"${agent_id}\".provider // \"anthropic\"" "$SETTINGS_FILE" 2>/dev/null)
+        cur_model=$(jq -r "(.agents // {}).\"${agent_id}\".model // empty" "$SETTINGS_FILE" 2>/dev/null)
+        agent_name=$(jq -r "(.agents // {}).\"${agent_id}\".name // \"${agent_id}\"" "$SETTINGS_FILE" 2>/dev/null)
+        echo -e "${BLUE}Agent: @${agent_id} (${agent_name})${NC}"
+        echo -e "${BLUE}Provider: ${GREEN}${cur_provider}${NC}"
+        if [ -n "$cur_model" ]; then
+            echo -e "${BLUE}Model:    ${GREEN}${cur_model}${NC}"
+        fi
+        return
+    fi
+
+    local tmp_file="$SETTINGS_FILE.tmp"
+
+    case "$provider_arg" in
+        anthropic)
+            if [ -n "$model_arg" ]; then
+                jq --arg id "$agent_id" --arg model "$model_arg" \
+                    '.agents[$id].provider = "anthropic" | .agents[$id].model = $model' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to Anthropic with model: ${model_arg}${NC}"
+            else
+                jq --arg id "$agent_id" \
+                    '.agents[$id].provider = "anthropic"' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to Anthropic${NC}"
+                echo ""
+                echo "Use 'tinyclaw agent provider ${agent_id} anthropic --model {sonnet|opus}' to also set the model."
+            fi
+            ;;
+        openai)
+            if [ -n "$model_arg" ]; then
+                jq --arg id "$agent_id" --arg model "$model_arg" \
+                    '.agents[$id].provider = "openai" | .agents[$id].model = $model' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to OpenAI with model: ${model_arg}${NC}"
+            else
+                jq --arg id "$agent_id" \
+                    '.agents[$id].provider = "openai"' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to OpenAI${NC}"
+                echo ""
+                echo "Use 'tinyclaw agent provider ${agent_id} openai --model {gpt-5.3-codex|gpt-5.2}' to also set the model."
+            fi
+            ;;
+        *)
+            echo "Usage: tinyclaw agent provider <agent_id> {anthropic|openai} [--model MODEL_NAME]"
+            echo ""
+            echo "Examples:"
+            echo "  tinyclaw agent provider coder                                    # Show current provider/model"
+            echo "  tinyclaw agent provider coder anthropic                           # Switch to Anthropic"
+            echo "  tinyclaw agent provider coder openai                              # Switch to OpenAI"
+            echo "  tinyclaw agent provider coder anthropic --model opus              # Switch to Anthropic Opus"
+            echo "  tinyclaw agent provider coder openai --model gpt-5.3-codex        # Switch to OpenAI GPT-5.3 Codex"
+            exit 1
+            ;;
+    esac
+
+    echo ""
+    echo "Note: Changes take effect on next message. Restart is not required."
+}
+
 # Reset a specific agent's conversation
 agent_reset() {
     local agent_id="$1"

--- a/tinyclaw.sh
+++ b/tinyclaw.sh
@@ -273,8 +273,22 @@ case "${1:-}" in
                 shift 2  # remove 'agent' and 'reset'
                 agent_reset_multiple "$@"
                 ;;
+            provider)
+                if [ -z "$3" ]; then
+                    echo "Usage: $0 agent provider <agent_id> [provider] [--model MODEL_NAME]"
+                    echo ""
+                    echo "Examples:"
+                    echo "  $0 agent provider coder                                    # Show current provider/model"
+                    echo "  $0 agent provider coder anthropic                           # Switch to Anthropic"
+                    echo "  $0 agent provider coder openai                              # Switch to OpenAI"
+                    echo "  $0 agent provider coder anthropic --model opus              # Switch to Anthropic Opus"
+                    echo "  $0 agent provider coder openai --model gpt-5.3-codex        # Switch to OpenAI GPT-5.3 Codex"
+                    exit 1
+                fi
+                agent_provider "$3" "$4" "$5" "$6"
+                ;;
             *)
-                echo "Usage: $0 agent {list|add|remove|show|reset}"
+                echo "Usage: $0 agent {list|add|remove|show|reset|provider}"
                 echo ""
                 echo "Agent Commands:"
                 echo "  list                   List all configured agents"
@@ -282,6 +296,7 @@ case "${1:-}" in
                 echo "  remove <id>            Remove an agent"
                 echo "  show <id>              Show agent configuration"
                 echo "  reset <id> [id2 ...]   Reset agent conversation(s)"
+                echo "  provider <id> [...]    Show or set agent's provider and model"
                 echo ""
                 echo "Examples:"
                 echo "  $0 agent list"
@@ -290,6 +305,7 @@ case "${1:-}" in
                 echo "  $0 agent remove coder"
                 echo "  $0 agent reset coder"
                 echo "  $0 agent reset coder researcher"
+                echo "  $0 agent provider coder anthropic --model opus"
                 echo ""
                 echo "In chat, use '@agent_id message' to route to a specific agent."
                 exit 1
@@ -389,7 +405,7 @@ case "${1:-}" in
         echo "  channels reset <channel> Reset channel auth ($local_names)"
         echo "  provider [name] [--model model]  Show or switch AI provider"
         echo "  model [name]             Show or switch AI model"
-        echo "  agent {list|add|remove|show|reset}  Manage agents"
+        echo "  agent {list|add|remove|show|reset|provider}  Manage agents"
         echo "  team {list|add|remove|show|visualize}  Manage teams"
         echo "  pairing {pending|approved|list|approve <code>|unpair <channel> <sender_id>}  Manage sender approvals"
         echo "  update                   Update TinyClaw to latest version"


### PR DESCRIPTION
## Summary
This PR adds a new `agent provider` command that allows users to view and configure the AI provider (Anthropic or OpenAI) and model for individual agents.

## Key Changes
- **New `agent_provider()` function** in `lib/agents.sh`:
  - Displays current provider and model when called without arguments
  - Supports switching between Anthropic and OpenAI providers
  - Allows setting a specific model via `--model` flag
  - Validates agent existence and provides helpful error messages with available agents
  - Updates settings file using `jq` for safe JSON manipulation
  - Provides user-friendly feedback and usage examples

- **Updated CLI routing** in `tinyclaw.sh`:
  - Added `provider` subcommand handler under `agent` command
  - Passes agent ID and optional provider/model arguments to `agent_provider()`
  - Updated help text to include the new `provider` command
  - Added examples showing provider switching with and without model specification

## Implementation Details
- The command supports three usage patterns:
  1. `tinyclaw agent provider <agent_id>` - Display current configuration
  2. `tinyclaw agent provider <agent_id> {anthropic|openai}` - Switch provider
  3. `tinyclaw agent provider <agent_id> {anthropic|openai} --model MODEL_NAME` - Switch provider and set model
- Changes take effect immediately on the next message without requiring a restart
- Maintains backward compatibility with existing agent commands

https://claude.ai/code/session_01FkQ7d2jzWfi2zVj3yadDmZ