### PR TITLE
Add Railway template with env-based settings bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ git clone https://github.com/jlia0/tinyclaw.git
 cd tinyclaw && npm install && ./scripts/install.sh
 ```
 
+### Railway (Template-Friendly)
+
+TinyClaw can run on Railway without interactive setup by generating `.tinyclaw/settings.json` from env vars at startup.
+
+See: [docs/RAILWAY.md](docs/RAILWAY.md)
+
 ### First Run
 
 ```bash
@@ -501,6 +507,7 @@ All channels share agent conversations!
 - [AGENTS.md](docs/AGENTS.md) - Agent management and routing
 - [TEAMS.md](docs/TEAMS.md) - Team collaboration, chain execution, and visualizer
 - [QUEUE.md](docs/QUEUE.md) - Queue system and message flow
+- [RAILWAY.md](docs/RAILWAY.md) - Railway deployment and env-based setup
 - [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) - Common issues and solutions
 
 ## 🐛 Troubleshooting

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -1,0 +1,58 @@
+# Railway Deploy (No UI Setup Wizard)
+
+TinyClaw can run on Railway without the interactive `tinyclaw setup` wizard.
+
+This repo includes:
+
+- `railway.json` for build/deploy commands
+- `scripts/railway-bootstrap-settings.mjs` to generate `.tinyclaw/settings.json` from environment variables
+- `scripts/railway-start.sh` to run channel workers + queue processor
+
+## 1. Create a Railway project from this repo
+
+Railway will detect `railway.json` automatically.
+
+## 2. Add environment variables
+
+At minimum (Telegram + OpenAI/Codex):
+
+- `TINYCLAW_CHANNELS=telegram`
+- `TELEGRAM_BOT_TOKEN=...`
+- `TINYCLAW_PROVIDER=openai`
+- `TINYCLAW_MODEL=gpt-5.3-codex`
+- `OPENAI_API_KEY=...`
+
+Optional:
+
+- `TINYCLAW_OPENAI_BASE_URL=https://openrouter.ai/api/v1`
+- `TINYCLAW_WORKSPACE_PATH=/app/tinyclaw-workspace`
+- `TINYCLAW_DEFAULT_AGENT_ID=assistant`
+- `TINYCLAW_DEFAULT_AGENT_NAME=Assistant`
+- `TINYCLAW_HEARTBEAT_INTERVAL=3600`
+- `TINYCLAW_ENABLE_HEARTBEAT=true`
+- `DISCORD_BOT_TOKEN=...` (if `discord` channel enabled)
+
+## 3. Advanced config (full JSON)
+
+If you want full control over agents/teams/channels, set one variable:
+
+- `TINYCLAW_SETTINGS_JSON` (raw JSON string), or
+- `TINYCLAW_SETTINGS_B64` (base64-encoded JSON)
+
+When present, these override the simple env-based generator.
+
+## 4. How config works at runtime
+
+On startup:
+
+1. `scripts/railway-bootstrap-settings.mjs` writes `.tinyclaw/settings.json`
+2. `scripts/railway-start.sh` starts:
+   - enabled channel clients
+   - `dist/queue-processor.js`
+   - optional heartbeat worker
+
+## Notes
+
+- OpenAI provider requires `codex` CLI; `railway.json` installs `@openai/codex` during build.
+- Anthropic provider requires `claude` CLI, which is not installed by default in this template.
+- WhatsApp is technically supported but usually not ideal for headless cloud deploys due QR/device linking.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://backboard.railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm install && npm run build && npm install --no-save @openai/codex"
+  },
+  "deploy": {
+    "startCommand": "bash ./scripts/railway-start.sh",
+    "restartPolicyType": "ALWAYS",
+    "restartPolicyMaxRetries": 10,
+    "sleepApplication": false
+  }
+}

--- a/scripts/railway-bootstrap-settings.mjs
+++ b/scripts/railway-bootstrap-settings.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const tinyclawDir = path.join(projectRoot, '.tinyclaw');
+const settingsFile = path.join(tinyclawDir, 'settings.json');
+
+function toInt(value, fallback) {
+    const num = Number(value);
+    return Number.isFinite(num) && num > 0 ? Math.floor(num) : fallback;
+}
+
+function parseCsv(value, fallback = []) {
+    if (!value || typeof value !== 'string') {
+        return fallback;
+    }
+    return value
+        .split(',')
+        .map(v => v.trim().toLowerCase())
+        .filter(Boolean);
+}
+
+function sanitizeId(value, fallback) {
+    const clean = String(value || fallback)
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '');
+    return clean || fallback;
+}
+
+function ensureDir(dir) {
+    fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeJson(filePath, data) {
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function loadSettingsFromEnv() {
+    const rawJson = process.env.TINYCLAW_SETTINGS_JSON;
+    if (rawJson) {
+        return JSON.parse(rawJson);
+    }
+
+    const b64 = process.env.TINYCLAW_SETTINGS_B64;
+    if (b64) {
+        return JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
+    }
+
+    const workspacePath = process.env.TINYCLAW_WORKSPACE_PATH || path.join(projectRoot, 'tinyclaw-workspace');
+    const workspaceName = process.env.TINYCLAW_WORKSPACE_NAME || path.basename(workspacePath);
+    const channels = parseCsv(process.env.TINYCLAW_CHANNELS, ['telegram']);
+    const provider = (process.env.TINYCLAW_PROVIDER || 'openai').toLowerCase();
+    const model = process.env.TINYCLAW_MODEL || (provider === 'openai' ? 'gpt-5.3-codex' : 'sonnet');
+
+    const defaultAgentId = sanitizeId(process.env.TINYCLAW_DEFAULT_AGENT_ID, 'assistant');
+    const defaultAgentName = process.env.TINYCLAW_DEFAULT_AGENT_NAME || 'Assistant';
+    const heartbeatInterval = toInt(process.env.TINYCLAW_HEARTBEAT_INTERVAL, 3600);
+
+    const openaiApiKey = process.env.TINYCLAW_OPENAI_API_KEY || process.env.OPENAI_API_KEY || '';
+    const openaiBaseUrl = process.env.TINYCLAW_OPENAI_BASE_URL || process.env.OPENAI_BASE_URL || '';
+
+    let agents;
+    if (process.env.TINYCLAW_AGENTS_JSON) {
+        agents = JSON.parse(process.env.TINYCLAW_AGENTS_JSON);
+    } else {
+        const defaultAgent = {
+            name: defaultAgentName,
+            provider,
+            model,
+            working_directory: path.join(workspacePath, defaultAgentId),
+        };
+        if (provider === 'openai' && (openaiApiKey || openaiBaseUrl)) {
+            defaultAgent.openai = {
+                ...(openaiBaseUrl ? { base_url: openaiBaseUrl } : {}),
+                ...(openaiApiKey ? { api_key: openaiApiKey } : {}),
+            };
+        }
+        agents = { [defaultAgentId]: defaultAgent };
+    }
+
+    const settings = {
+        workspace: {
+            path: workspacePath,
+            name: workspaceName,
+        },
+        channels: {
+            enabled: channels,
+            discord: { bot_token: process.env.DISCORD_BOT_TOKEN || '' },
+            telegram: { bot_token: process.env.TELEGRAM_BOT_TOKEN || '' },
+            whatsapp: {},
+        },
+        agents,
+        models: provider === 'openai'
+            ? {
+                provider: 'openai',
+                openai: {
+                    model,
+                    ...(openaiBaseUrl ? { base_url: openaiBaseUrl } : {}),
+                    ...(openaiApiKey ? { api_key: openaiApiKey } : {}),
+                },
+            }
+            : {
+                provider: 'anthropic',
+                anthropic: { model },
+            },
+        monitoring: {
+            heartbeat_interval: heartbeatInterval,
+        },
+    };
+
+    if (process.env.TINYCLAW_TEAMS_JSON) {
+        settings.teams = JSON.parse(process.env.TINYCLAW_TEAMS_JSON);
+    }
+
+    return settings;
+}
+
+function validateSettings(settings) {
+    const channels = settings?.channels?.enabled || [];
+    if (!Array.isArray(channels) || channels.length === 0) {
+        throw new Error('settings.channels.enabled must include at least one channel');
+    }
+
+    if (channels.includes('telegram')) {
+        const token = settings?.channels?.telegram?.bot_token || process.env.TELEGRAM_BOT_TOKEN;
+        if (!token) {
+            throw new Error('Telegram is enabled but TELEGRAM_BOT_TOKEN is missing');
+        }
+    }
+
+    if (channels.includes('discord')) {
+        const token = settings?.channels?.discord?.bot_token || process.env.DISCORD_BOT_TOKEN;
+        if (!token) {
+            throw new Error('Discord is enabled but DISCORD_BOT_TOKEN is missing');
+        }
+    }
+}
+
+function ensureRuntimeDirectories(settings) {
+    const workspacePath = settings?.workspace?.path || path.join(projectRoot, 'tinyclaw-workspace');
+    const queueBase = path.join(tinyclawDir, 'queue');
+    [
+        path.join(queueBase, 'incoming'),
+        path.join(queueBase, 'processing'),
+        path.join(queueBase, 'outgoing'),
+        path.join(tinyclawDir, 'logs'),
+        path.join(tinyclawDir, 'channels'),
+        path.join(tinyclawDir, 'files'),
+        path.join(tinyclawDir, 'events'),
+        path.join(tinyclawDir, 'chats'),
+        workspacePath,
+    ].forEach(ensureDir);
+
+    const agents = settings?.agents || {};
+    for (const agent of Object.values(agents)) {
+        if (agent && agent.working_directory) {
+            ensureDir(agent.working_directory);
+        }
+    }
+}
+
+try {
+    ensureDir(tinyclawDir);
+    const settings = loadSettingsFromEnv();
+    validateSettings(settings);
+    ensureRuntimeDirectories(settings);
+    writeJson(settingsFile, settings);
+    console.log(`[railway] wrote settings: ${settingsFile}`);
+} catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[railway] failed to bootstrap settings: ${message}`);
+    process.exit(1);
+}

--- a/scripts/railway-start.sh
+++ b/scripts/railway-start.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETTINGS_FILE="$PROJECT_ROOT/.tinyclaw/settings.json"
+
+cd "$PROJECT_ROOT"
+export PATH="$PROJECT_ROOT/node_modules/.bin:$PATH"
+
+if command -v npm >/dev/null 2>&1; then
+    NPM_PREFIX="$(npm config get prefix 2>/dev/null || true)"
+    if [ -n "$NPM_PREFIX" ] && [ -d "$NPM_PREFIX/bin" ]; then
+        export PATH="$NPM_PREFIX/bin:$PATH"
+    fi
+fi
+
+node "$PROJECT_ROOT/scripts/railway-bootstrap-settings.mjs"
+
+if [ ! -d "$PROJECT_ROOT/dist" ]; then
+    npm run build
+fi
+
+if [ ! -f "$SETTINGS_FILE" ]; then
+    echo "[railway] settings file missing at $SETTINGS_FILE"
+    exit 1
+fi
+
+mapfile -t ACTIVE_CHANNELS < <(node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));for(const c of (s.channels?.enabled||[])) console.log(c);" "$SETTINGS_FILE")
+
+if [ "${#ACTIVE_CHANNELS[@]}" -eq 0 ]; then
+    echo "[railway] no channels enabled in settings"
+    exit 1
+fi
+
+mapfile -t PROVIDERS < <(node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const set=new Set();for(const a of Object.values(s.agents||{})){if(a&&a.provider)set.add(String(a.provider).toLowerCase())}for(const p of set) console.log(p);" "$SETTINGS_FILE")
+
+for provider in "${PROVIDERS[@]}"; do
+    case "$provider" in
+        openai)
+            if ! command -v codex >/dev/null 2>&1; then
+                echo "[railway] provider 'openai' requires 'codex' CLI in PATH"
+                echo "[railway] install with: npm install -g @openai/codex"
+                exit 1
+            fi
+            ;;
+        anthropic)
+            if ! command -v claude >/dev/null 2>&1; then
+                echo "[railway] provider 'anthropic' requires 'claude' CLI in PATH"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+PIDS=()
+
+start_proc() {
+    local name="$1"
+    shift
+    echo "[railway] starting ${name}: $*"
+    "$@" &
+    local pid=$!
+    PIDS+=("$pid")
+    echo "[railway] started ${name} (pid=$pid)"
+}
+
+for ch in "${ACTIVE_CHANNELS[@]}"; do
+    case "$ch" in
+        telegram)
+            start_proc "telegram" node "$PROJECT_ROOT/dist/channels/telegram-client.js"
+            ;;
+        discord)
+            start_proc "discord" node "$PROJECT_ROOT/dist/channels/discord-client.js"
+            ;;
+        whatsapp)
+            start_proc "whatsapp" node "$PROJECT_ROOT/dist/channels/whatsapp-client.js"
+            ;;
+        *)
+            echo "[railway] unsupported channel '${ch}' in settings, skipping"
+            ;;
+    esac
+done
+
+start_proc "queue" node "$PROJECT_ROOT/dist/queue-processor.js"
+
+if [ "${TINYCLAW_ENABLE_HEARTBEAT:-false}" = "true" ]; then
+    start_proc "heartbeat" bash "$PROJECT_ROOT/lib/heartbeat-cron.sh"
+fi
+
+cleanup() {
+    echo "[railway] shutting down..."
+    for pid in "${PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+
+trap cleanup SIGINT SIGTERM
+
+set +e
+wait -n
+exit_code=$?
+set -e
+
+echo "[railway] one process exited (code=$exit_code), stopping all..."
+cleanup
+wait || true
+exit "$exit_code"


### PR DESCRIPTION
## Summary
- add `railway.json` so Railway can build and run TinyClaw as a worker service
- add `scripts/railway-bootstrap-settings.mjs` to generate `.tinyclaw/settings.json` from env vars (or raw/base64 JSON)
- add `scripts/railway-start.sh` to launch channel clients + queue processor without tmux
- add `docs/RAILWAY.md` with exact env var setup steps for Telegram/model/provider config
- link Railway docs from README

## Why
Railway deployments do not use the interactive setup wizard, so this enables non-interactive channel/model configuration and a template-friendly startup path.

## Validation
- `bash -n scripts/railway-start.sh`
- `node scripts/railway-bootstrap-settings.mjs` (with required env vars)
- `npm run build`
