### PR TITLE
fix: change WhatsApp headless flag from true to new (stealth)

### DIFF
--- a/src/channels/whatsapp-client.ts
+++ b/src/channels/whatsapp-client.ts
@@ -178,7 +178,9 @@ const client = new Client({
         dataPath: SESSION_DIR
     }),
     puppeteer: {
-        headless: true,
+        headless: process.env.TINYCLAW_HEADLESS === 'false'
+            ? false
+            : (process.env.TINYCLAW_HEADLESS || 'new') as any,
         args: [
             '--no-sandbox',
             '--disable-setuid-sandbox',


### PR DESCRIPTION
Replaces hardcoded `headless: true` with env-var-driven config:

- `TINYCLAW_HEADLESS`: set `'false'` for display, `'new'` for stealth headless (default), `'true'` for basic headless

Fixes #74