### PR TITLE
fix: resolve TINYCLAW_HOME consistently for installed CLI vs local dev

### DIFF
--- a/.agents/skills/schedule/scripts/schedule.sh
+++ b/.agents/skills/schedule/scripts/schedule.sh
@@ -26,10 +26,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="${TINYCLAW_PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
 # Resolve TINYCLAW_HOME (same logic as the TypeScript config)
-if [ -f "$PROJECT_ROOT/.tinyclaw/settings.json" ]; then
-    TINYCLAW_HOME="$PROJECT_ROOT/.tinyclaw"
-else
-    TINYCLAW_HOME="$HOME/.tinyclaw"
+if [ -z "$TINYCLAW_HOME" ]; then
+    if [ -f "$PROJECT_ROOT/.tinyclaw/settings.json" ]; then
+        TINYCLAW_HOME="$PROJECT_ROOT/.tinyclaw"
+    else
+        TINYCLAW_HOME="$HOME/.tinyclaw"
+    fi
 fi
 
 QUEUE_INCOMING="$TINYCLAW_HOME/queue/incoming"

--- a/bin/tinyclaw
+++ b/bin/tinyclaw
@@ -17,7 +17,10 @@ done
 TINYCLAW_DIR="$(cd "$(dirname "$TINYCLAW_BIN")" && pwd)"
 
 # The actual installation is one directory up from bin/
-export TINYCLAW_HOME="$(dirname "$TINYCLAW_DIR")"
+REPO_ROOT="$(dirname "$TINYCLAW_DIR")"
+
+# Installed CLI always uses ~/.tinyclaw for data
+export TINYCLAW_HOME="$HOME/.tinyclaw"
 
 # Execute the main script with all arguments
-exec "$TINYCLAW_HOME/tinyclaw.sh" "$@"
+exec "$REPO_ROOT/tinyclaw.sh" "$@"

--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -187,10 +187,12 @@ agent_add() {
         "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
 
     # Create agent directory and copy configuration files
-    if [ -f "$SCRIPT_DIR/.tinyclaw/settings.json" ]; then
-        TINYCLAW_HOME="$SCRIPT_DIR/.tinyclaw"
-    else
-        TINYCLAW_HOME="$HOME/.tinyclaw"
+    if [ -z "$TINYCLAW_HOME" ]; then
+        if [ -f "$SCRIPT_DIR/.tinyclaw/settings.json" ]; then
+            TINYCLAW_HOME="$SCRIPT_DIR/.tinyclaw"
+        else
+            TINYCLAW_HOME="$HOME/.tinyclaw"
+        fi
     fi
     mkdir -p "$AGENTS_DIR/$AGENT_ID"
 

--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -143,8 +143,8 @@ start_daemon() {
         echo -e "${YELLOW}Starting WhatsApp client...${NC}"
         echo ""
 
-        QR_FILE="$SCRIPT_DIR/.tinyclaw/channels/whatsapp_qr.txt"
-        READY_FILE="$SCRIPT_DIR/.tinyclaw/channels/whatsapp_ready"
+        QR_FILE="$TINYCLAW_HOME/channels/whatsapp_qr.txt"
+        READY_FILE="$TINYCLAW_HOME/channels/whatsapp_ready"
         QR_DISPLAYED=false
 
         for i in {1..60}; do
@@ -274,7 +274,7 @@ status_daemon() {
     echo ""
 
     # Channel process status
-    local ready_file="$SCRIPT_DIR/.tinyclaw/channels/whatsapp_ready"
+    local ready_file="$TINYCLAW_HOME/channels/whatsapp_ready"
 
     for ch in "${ALL_CHANNELS[@]}"; do
         local display="${CHANNEL_DISPLAY[$ch]}"

--- a/lib/heartbeat-cron.sh
+++ b/lib/heartbeat-cron.sh
@@ -3,15 +3,17 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if [ -f "$PROJECT_ROOT/.tinyclaw/settings.json" ]; then
-    TINYCLAW_HOME="$PROJECT_ROOT/.tinyclaw"
-else
-    TINYCLAW_HOME="$HOME/.tinyclaw"
+if [ -z "$TINYCLAW_HOME" ]; then
+    if [ -f "$PROJECT_ROOT/.tinyclaw/settings.json" ]; then
+        TINYCLAW_HOME="$PROJECT_ROOT/.tinyclaw"
+    else
+        TINYCLAW_HOME="$HOME/.tinyclaw"
+    fi
 fi
 LOG_FILE="$TINYCLAW_HOME/logs/heartbeat.log"
 QUEUE_INCOMING="$TINYCLAW_HOME/queue/incoming"
 QUEUE_OUTGOING="$TINYCLAW_HOME/queue/outgoing"
-SETTINGS_FILE="$PROJECT_ROOT/.tinyclaw/settings.json"
+SETTINGS_FILE="$TINYCLAW_HOME/settings.json"
 
 # Read interval from settings.json, default to 3600
 if [ -f "$SETTINGS_FILE" ]; then

--- a/src/channels/discord-client.ts
+++ b/src/channels/discord-client.ts
@@ -15,9 +15,10 @@ import { ensureSenderPaired } from '../lib/pairing';
 
 const SCRIPT_DIR = path.resolve(__dirname, '..', '..');
 const _localTinyclaw = path.join(SCRIPT_DIR, '.tinyclaw');
-const TINYCLAW_HOME = fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
-    ? _localTinyclaw
-    : path.join(require('os').homedir(), '.tinyclaw');
+const TINYCLAW_HOME = process.env.TINYCLAW_HOME
+    || (fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
+        ? _localTinyclaw
+        : path.join(require('os').homedir(), '.tinyclaw'));
 const QUEUE_INCOMING = path.join(TINYCLAW_HOME, 'queue/incoming');
 const QUEUE_OUTGOING = path.join(TINYCLAW_HOME, 'queue/outgoing');
 const LOG_FILE = path.join(TINYCLAW_HOME, 'logs/discord.log');

--- a/src/channels/telegram-client.ts
+++ b/src/channels/telegram-client.ts
@@ -17,9 +17,10 @@ import { ensureSenderPaired } from '../lib/pairing';
 
 const SCRIPT_DIR = path.resolve(__dirname, '..', '..');
 const _localTinyclaw = path.join(SCRIPT_DIR, '.tinyclaw');
-const TINYCLAW_HOME = fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
-    ? _localTinyclaw
-    : path.join(require('os').homedir(), '.tinyclaw');
+const TINYCLAW_HOME = process.env.TINYCLAW_HOME
+    || (fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
+        ? _localTinyclaw
+        : path.join(require('os').homedir(), '.tinyclaw'));
 const QUEUE_INCOMING = path.join(TINYCLAW_HOME, 'queue/incoming');
 const QUEUE_OUTGOING = path.join(TINYCLAW_HOME, 'queue/outgoing');
 const LOG_FILE = path.join(TINYCLAW_HOME, 'logs/telegram.log');

--- a/src/channels/whatsapp-client.ts
+++ b/src/channels/whatsapp-client.ts
@@ -13,9 +13,10 @@ import { ensureSenderPaired } from '../lib/pairing';
 
 const SCRIPT_DIR = path.resolve(__dirname, '..', '..');
 const _localTinyclaw = path.join(SCRIPT_DIR, '.tinyclaw');
-const TINYCLAW_HOME = fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
-    ? _localTinyclaw
-    : path.join(require('os').homedir(), '.tinyclaw');
+const TINYCLAW_HOME = process.env.TINYCLAW_HOME
+    || (fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
+        ? _localTinyclaw
+        : path.join(require('os').homedir(), '.tinyclaw'));
 const QUEUE_INCOMING = path.join(TINYCLAW_HOME, 'queue/incoming');
 const QUEUE_OUTGOING = path.join(TINYCLAW_HOME, 'queue/outgoing');
 const LOG_FILE = path.join(TINYCLAW_HOME, 'logs/whatsapp.log');

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,9 +4,10 @@ import { Settings, AgentConfig, TeamConfig, CLAUDE_MODEL_IDS, CODEX_MODEL_IDS } 
 
 export const SCRIPT_DIR = path.resolve(__dirname, '../..');
 const _localTinyclaw = path.join(SCRIPT_DIR, '.tinyclaw');
-export const TINYCLAW_HOME = fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
-    ? _localTinyclaw
-    : path.join(require('os').homedir(), '.tinyclaw');
+export const TINYCLAW_HOME = process.env.TINYCLAW_HOME
+    || (fs.existsSync(path.join(_localTinyclaw, 'settings.json'))
+        ? _localTinyclaw
+        : path.join(require('os').homedir(), '.tinyclaw'));
 export const QUEUE_INCOMING = path.join(TINYCLAW_HOME, 'queue/incoming');
 export const QUEUE_OUTGOING = path.join(TINYCLAW_HOME, 'queue/outgoing');
 export const QUEUE_PROCESSING = path.join(TINYCLAW_HOME, 'queue/processing');

--- a/tinyclaw.sh
+++ b/tinyclaw.sh
@@ -7,20 +7,23 @@
 #   3. Fill in the CHANNEL_* registry arrays in lib/common.sh
 #   4. Run setup wizard to enable it
 
-# Use TINYCLAW_HOME if set (for CLI wrapper), otherwise detect from script location
-if [ -n "$TINYCLAW_HOME" ]; then
-    SCRIPT_DIR="$TINYCLAW_HOME"
-else
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# SCRIPT_DIR = repo root (where bash scripts live)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# TINYCLAW_HOME = data directory (settings, queue, logs, etc.)
+# - Installed CLI sets this to ~/.tinyclaw via bin/tinyclaw
+# - Local dev: detect from local .tinyclaw/ or fall back to ~/.tinyclaw
+if [ -z "$TINYCLAW_HOME" ]; then
+    if [ -f "$SCRIPT_DIR/.tinyclaw/settings.json" ]; then
+        TINYCLAW_HOME="$SCRIPT_DIR/.tinyclaw"
+    else
+        TINYCLAW_HOME="$HOME/.tinyclaw"
+    fi
 fi
+
 TMUX_SESSION="tinyclaw"
-# Centralize all logs to ~/.tinyclaw/logs
-LOG_DIR="$HOME/.tinyclaw/logs"
-if [ -f "$SCRIPT_DIR/.tinyclaw/settings.json" ]; then
-    SETTINGS_FILE="$SCRIPT_DIR/.tinyclaw/settings.json"
-else
-    SETTINGS_FILE="$HOME/.tinyclaw/settings.json"
-fi
+LOG_DIR="$TINYCLAW_HOME/logs"
+SETTINGS_FILE="$TINYCLAW_HOME/settings.json"
 
 mkdir -p "$LOG_DIR"
 


### PR DESCRIPTION
## Summary
- Installed CLI (`tinyclaw start`) and local dev (`./tinyclaw.sh start`) were both resolving `TINYCLAW_HOME` via `__dirname`, which always pointed to the repo's `.tinyclaw/` when `settings.json` existed there — even for the installed CLI that should use `~/.tinyclaw`
- `TINYCLAW_HOME` now has a single clear meaning: the data directory (settings, queue, logs, events, chats)
- `bin/tinyclaw` exports `TINYCLAW_HOME=~/.tinyclaw` so the installed CLI always uses `~/.tinyclaw`
- Local dev auto-detects from `<repo>/.tinyclaw/` or falls back to `~/.tinyclaw`
- All TypeScript and bash scripts respect the env var when set

## Test plan
- [ ] Run `tinyclaw start` via installed CLI — verify queue processor watches `~/.tinyclaw/queue/incoming`
- [ ] Run `./tinyclaw.sh start` from repo — verify it uses `<repo>/.tinyclaw/queue/incoming`
- [ ] Send a message via Telegram and verify it gets processed by the queue processor
- [ ] Verify `tinyclaw agent add` copies template files correctly
- [ ] Verify heartbeat cron writes to the correct queue directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)