### PR TITLE
fix: unify proactive message delivery via senderId fallback

### DIFF
--- a/.agents/skills/send-user-message/SKILL.md
+++ b/.agents/skills/send-user-message/SKILL.md
@@ -37,13 +37,24 @@ This reads `pairing.json` and prints all approved pairings with their `channel`,
   --message "<your message>"
 ```
 
+With file attachments:
+
+```bash
+<skill_dir>/scripts/send-message.sh send \
+  --channel telegram \
+  --sender-id 123456 \
+  --sender "Alice" \
+  --message "Here's the report you requested." \
+  --files "/Users/you/.tinyclaw/files/report.pdf,/Users/you/.tinyclaw/files/chart.png"
+```
+
 Parameters:
 - `--channel`: One of `discord`, `telegram`, `whatsapp`
 - `--sender-id`: The channel-specific user ID (from pairing.json or conversation context)
 - `--sender`: Human-readable display name of the recipient
 - `--message`: The message text to send (max 4000 chars)
 - `--agent`: (Optional) Agent ID to attribute the message to
-- `--files`: (Optional) Comma-separated absolute file paths to attach
+- `--files`: (Optional) Comma-separated absolute file paths to attach (files must exist on disk)
 
 The script writes a JSON file to the outgoing queue directory with the correct `{channel}_` prefix so the channel client picks it up.
 

--- a/src/channels/whatsapp-client.ts
+++ b/src/channels/whatsapp-client.ts
@@ -403,18 +403,29 @@ async function checkOutgoingQueue(): Promise<void> {
 
             try {
                 const responseData: ResponseData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-                const { messageId, message: responseText, sender } = responseData;
+                const { messageId, message: responseText, sender, senderId } = responseData;
 
-                // Find pending message
+                // Find pending message, or fall back to senderId for proactive messages
                 const pending = pendingMessages.get(messageId);
-                if (pending) {
+                let targetChat: Chat | null = pending?.chat ?? null;
+
+                if (!targetChat && senderId) {
+                    try {
+                        const chatId = senderId.includes('@') ? senderId : `${senderId}@c.us`;
+                        targetChat = await client.getChatById(chatId);
+                    } catch (err) {
+                        log('ERROR', `Could not get chat for senderId ${senderId}: ${(err as Error).message}`);
+                    }
+                }
+
+                if (targetChat) {
                     // Send any attached files first
                     if (responseData.files && responseData.files.length > 0) {
                         for (const file of responseData.files) {
                             try {
                                 if (!fs.existsSync(file)) continue;
                                 const media = MessageMedia.fromFilePath(file);
-                                await pending.chat.sendMessage(media);
+                                await targetChat.sendMessage(media);
                                 log('INFO', `Sent file to WhatsApp: ${path.basename(file)}`);
                             } catch (fileErr) {
                                 log('ERROR', `Failed to send file ${file}: ${(fileErr as Error).message}`);
@@ -424,42 +435,16 @@ async function checkOutgoingQueue(): Promise<void> {
 
                     // Send text response
                     if (responseText) {
-                        pending.message.reply(responseText);
-                    }
-                    log('INFO', `✓ Sent response to ${sender} (${responseText.length} chars${responseData.files ? `, ${responseData.files.length} file(s)` : ''})`);
-
-                    // Clean up
-                    pendingMessages.delete(messageId);
-                    fs.unlinkSync(filePath);
-                } else if (responseData.senderId) {
-                    // Proactive/agent-initiated message — send directly to user
-                    try {
-                        const chatId = responseData.senderId.includes('@') ? responseData.senderId : `${responseData.senderId}@c.us`;
-                        const chat = await client.getChatById(chatId);
-
-                        // Send any attached files first
-                        if (responseData.files && responseData.files.length > 0) {
-                            for (const file of responseData.files) {
-                                try {
-                                    if (!fs.existsSync(file)) continue;
-                                    const media = MessageMedia.fromFilePath(file);
-                                    await chat.sendMessage(media);
-                                    log('INFO', `Sent file to WhatsApp: ${path.basename(file)}`);
-                                } catch (fileErr) {
-                                    log('ERROR', `Failed to send file ${file}: ${(fileErr as Error).message}`);
-                                }
-                            }
+                        if (pending) {
+                            await pending.message.reply(responseText);
+                        } else {
+                            await targetChat.sendMessage(responseText);
                         }
-
-                        // Send text message
-                        if (responseText) {
-                            await chat.sendMessage(responseText);
-                        }
-
-                        log('INFO', `Sent proactive message to ${sender} (${responseText.length} chars${responseData.files ? `, ${responseData.files.length} file(s)` : ''})`);
-                    } catch (chatErr) {
-                        log('ERROR', `Failed to send proactive message to ${responseData.senderId}: ${(chatErr as Error).message}`);
                     }
+
+                    log('INFO', `Sent ${pending ? 'response' : 'proactive message'} to ${sender} (${responseText.length} chars${responseData.files ? `, ${responseData.files.length} file(s)` : ''})`);
+
+                    if (pending) pendingMessages.delete(messageId);
                     fs.unlinkSync(filePath);
                 } else {
                     log('WARN', `No pending message for ${messageId} and no senderId, cleaning up`);


### PR DESCRIPTION
## Summary

- Channel clients (Telegram, Discord, WhatsApp) now use a single unified code path for both request-response and proactive message delivery
- Resolves target from `pendingMessages` first, falls back to `senderId` for proactive messages
- Removes ~40 lines of duplicated logic per client (the old `else if (senderId)` branches)
- Fixes missing `await` on WhatsApp `pending.message.reply()`
- Adds `NaN` guard for Telegram senderId parsing
- Preserves WhatsApp `@c.us` suffix handling for chat ID resolution
- Adds `--files` usage example to send-user-message SKILL.md

Supersedes #79 — same problem, cleaner fix with dead code removed.

## Test plan

- [ ] Proactive message via `send-message.sh send --channel telegram` delivers successfully
- [ ] Proactive message with `--files` attaches files correctly
- [ ] Normal request-response flow still replies to original message
- [ ] TypeScript build passes cleanly (`npx tsc --noEmit` ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)