### PR TITLE
feat: per-agent Telegram bots

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,9 @@ export interface AgentConfig {
     provider: string;       // 'anthropic' or 'openai'
     model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex'
     working_directory: string;
+    telegram?: {
+        bot_token?: string;
+    };
 }
 
 export interface TeamConfig {


### PR DESCRIPTION
## Summary
- Each agent can have its own dedicated Telegram bot (configured via `telegram.bot_token` in agent config)
- Messages from agent-specific bots are pre-routed to the correct agent automatically
- Agent bot `getMe()` failures are handled gracefully (log + disable, no `process.exit(1)`)
- Bare `/reset` on an agent bot auto-resets that agent
- Telegram bot prompt added to both `tinyclaw setup` wizard and `tinyclaw agent add`
- Bot commands (`/agent`, `/team`, `/reset`) registered on all bot instances

Supersedes #52 — rebased on current `main` (v0.0.5), incorporates upstream changes (unified `targetChatId`, `setMyCommands`, `TINYCLAW_HOME` env var support).

## Files changed
- `src/lib/types.ts` — add `telegram.bot_token` to `AgentConfig`
- `src/channels/telegram-client.ts` — multi-bot architecture refactor
- `lib/agents.sh` — telegram bot prompt in `agent_add()`
- `lib/setup-wizard.sh` — telegram bot prompt in setup wizard

## Test plan
- [ ] `npm run build` passes
- [ ] Main bot token validation still works (exit on missing token)
- [ ] Agent bot failures are gracefully handled (log + disable, no process.exit)
- [ ] `/reset`, `/agent`, `/team` commands work on all bot instances
- [ ] Bare `/reset` on agent bot auto-resets that agent
- [ ] Proactive messaging works via senderId fallback to main bot
- [ ] `tinyclaw agent add` prompts for telegram bot token
- [ ] `tinyclaw setup` prompts for telegram bot token per agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)