### PR TITLE
feat: add audio transcription (speech-to-text) for voice messages

### DIFF
--- a/src/lib/transcription.ts
+++ b/src/lib/transcription.ts
@@ -1,0 +1,149 @@
+import fs from 'fs';
+import path from 'path';
+import https from 'https';
+import http from 'http';
+import { URL } from 'url';
+import { log } from './logging';
+
+export interface TranscriptionConfig {
+    enabled?: boolean;
+    base_url?: string;
+    api_key?: string;
+    model?: string;
+    retain_audio?: boolean;
+}
+
+const AUDIO_EXTENSIONS = new Set(['.ogg', '.mp3', '.wav', '.m4a', '.flac', '.opus', '.oga', '.webm']);
+
+export function isAudioFile(filePath: string): boolean {
+    const ext = path.extname(filePath).toLowerCase();
+    return AUDIO_EXTENSIONS.has(ext);
+}
+
+export function extractAudioFiles(message: string): string[] {
+    const fileRegex = /\[file:\s*([^\]]+)\]/g;
+    const audioFiles: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = fileRegex.exec(message)) !== null) {
+        const filePath = match[1].trim();
+        if (isAudioFile(filePath)) {
+            audioFiles.push(filePath);
+        }
+    }
+    return audioFiles;
+}
+
+export async function transcribeAudio(filePath: string, config: TranscriptionConfig): Promise<string> {
+    const baseUrl = config.base_url || 'https://api.mistral.ai/v1';
+    const apiKey = config.api_key || process.env.TRANSCRIPTION_API_KEY;
+    const model = config.model || 'voxtral-mini-latest';
+
+    if (!apiKey) {
+        throw new Error('Transcription API key not configured (set transcription.api_key or TRANSCRIPTION_API_KEY env)');
+    }
+
+    const url = new URL(`${baseUrl}/audio/transcriptions`);
+    const fileData = fs.readFileSync(filePath);
+    const filename = path.basename(filePath);
+
+    // Build multipart form data
+    const boundary = `----TinyClawBoundary${Date.now()}${Math.random().toString(36).slice(2)}`;
+    const parts: Buffer[] = [];
+
+    // File field
+    parts.push(Buffer.from(
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+        `Content-Type: application/octet-stream\r\n\r\n`
+    ));
+    parts.push(fileData);
+    parts.push(Buffer.from('\r\n'));
+
+    // Model field
+    parts.push(Buffer.from(
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="model"\r\n\r\n` +
+        `${model}\r\n`
+    ));
+
+    // Closing boundary
+    parts.push(Buffer.from(`--${boundary}--\r\n`));
+
+    const body = Buffer.concat(parts);
+
+    return new Promise((resolve, reject) => {
+        const options: https.RequestOptions = {
+            hostname: url.hostname,
+            port: url.port || (url.protocol === 'https:' ? 443 : 80),
+            path: url.pathname + url.search,
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type': `multipart/form-data; boundary=${boundary}`,
+                'Content-Length': body.length,
+            },
+        };
+
+        const requester = url.protocol === 'https:' ? https : http;
+        const req = requester.request(options, (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (chunk: Buffer) => chunks.push(chunk));
+            res.on('end', () => {
+                const responseBody = Buffer.concat(chunks).toString('utf8');
+                if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+                    try {
+                        const parsed = JSON.parse(responseBody);
+                        resolve(parsed.text || '');
+                    } catch {
+                        reject(new Error(`Failed to parse transcription response: ${responseBody.substring(0, 200)}`));
+                    }
+                } else {
+                    reject(new Error(`Transcription API error (${res.statusCode}): ${responseBody.substring(0, 200)}`));
+                }
+            });
+        });
+
+        req.on('error', reject);
+        req.write(body);
+        req.end();
+    });
+}
+
+export async function processAudioInMessage(message: string, config: TranscriptionConfig): Promise<string> {
+    const audioFiles = extractAudioFiles(message);
+    if (audioFiles.length === 0) return message;
+
+    let result = message;
+
+    for (const filePath of audioFiles) {
+        if (!fs.existsSync(filePath)) {
+            log('WARN', `Audio file not found for transcription: ${filePath}`);
+            continue;
+        }
+
+        try {
+            log('INFO', `Transcribing audio: ${path.basename(filePath)}`);
+            const transcription = await transcribeAudio(filePath, config);
+            log('INFO', `Transcription complete: ${transcription.substring(0, 80)}...`);
+
+            const escaped = transcription.replace(/"/g, '\\"');
+            const replacement = `[voice transcription: "${escaped}"]`;
+            result = result.replace(`[file: ${filePath}]`, replacement);
+
+            // Delete audio file unless retain_audio is set
+            if (!config.retain_audio) {
+                try {
+                    fs.unlinkSync(filePath);
+                    log('INFO', `Deleted audio file: ${path.basename(filePath)}`);
+                } catch (e) {
+                    log('WARN', `Failed to delete audio file: ${(e as Error).message}`);
+                }
+            }
+        } catch (error) {
+            log('ERROR', `Transcription failed for ${path.basename(filePath)}: ${(error as Error).message}`);
+            // Leave the original [file: ...] reference intact on failure
+        }
+    }
+
+    return result;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,13 @@ export interface Settings {
     monitoring?: {
         heartbeat_interval?: number;
     };
+    transcription?: {
+        enabled?: boolean;
+        base_url?: string;
+        api_key?: string;
+        model?: string;
+        retain_audio?: boolean;
+    };
 }
 
 export interface MessageData {

--- a/src/queue-processor.ts
+++ b/src/queue-processor.ts
@@ -25,6 +25,7 @@ import {
 import { log, emitEvent } from './lib/logging';
 import { parseAgentRouting, findTeamForAgent, getAgentResetFlag, extractTeammateMentions } from './lib/routing';
 import { invokeAgent } from './lib/invoke';
+import { processAudioInMessage } from './lib/transcription';
 
 // Ensure directories exist
 [QUEUE_INCOMING, QUEUE_OUTGOING, QUEUE_PROCESSING, FILES_DIR, path.dirname(LOG_FILE)].forEach(dir => {
@@ -338,6 +339,12 @@ async function processMessage(messageFile: string): Promise<void> {
                     message += `\n\n------\n\n[${othersPending} other teammate response(s) are still being processed and will be delivered when ready. Do not re-mention teammates who haven't responded yet.]`;
                 }
             }
+        }
+
+        // Transcribe audio files if enabled
+        const transcriptionConfig = settings.transcription;
+        if (transcriptionConfig?.enabled) {
+            message = await processAudioInMessage(message, transcriptionConfig);
         }
 
         // Invoke agent


### PR DESCRIPTION
## Summary
- Adds automatic speech-to-text transcription for voice notes/audio messages before agent processing
- Uses any OpenAI-compatible STT API (e.g. Mistral Voxtral, OpenAI Whisper, Groq)
- Works cross-channel (Telegram, WhatsApp, Discord) via the shared queue processor — no channel-specific code needed

## Changes
- **`src/lib/types.ts`** — Add `transcription` config block to `Settings`
- **`src/lib/transcription.ts`** *(new)* — Transcription module: audio detection, multipart upload, message transformation
- **`src/queue-processor.ts`** — 4-line integration before `invokeAgent()`

## How it works
1. Queue processor detects `[file: /path/to/voice.ogg]` references in incoming messages
2. Audio files are sent to the configured STT API endpoint
3. File references are replaced with `[voice transcription: "transcribed text"]`
4. On failure, the original file reference is preserved (fail-silent)

## Configuration
```json
{
  "transcription": {
    "enabled": true,
    "base_url": "https://api.mistral.ai/v1",
    "api_key": "your-key",
    "model": "voxtral-mini-latest",
    "retain_audio": false
  }
}
```

API key can also be set via `TRANSCRIPTION_API_KEY` env var.

## Test plan
- [ ] Configure transcription settings pointing to an OpenAI-compatible STT API
- [ ] Send a voice note via Telegram and verify transcribed text reaches the agent
- [ ] Verify audio file is deleted when `retain_audio: false`
- [ ] Verify graceful fallback when API is unavailable (file reference preserved)
- [ ] Test with non-audio file references to confirm they're left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)