### PR TITLE
fix: unset CLAUDECODE env var on daemon start

### DIFF
--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -4,6 +4,13 @@
 
 # Start daemon
 start_daemon() {
+    # When an AI agent (e.g. Claude Code) triggers a restart from inside the
+    # tmux session, CLAUDECODE=1 leaks into the environment.  The queue
+    # processor then inherits it, and every `claude` invocation fails with
+    # "cannot be launched inside another Claude Code session".  Strip it early
+    # so the entire daemon tree starts clean.
+    unset CLAUDECODE 2>/dev/null || true
+
     if session_exists; then
         echo -e "${YELLOW}Session already running${NC}"
         return 1


### PR DESCRIPTION
## Summary

- When an AI agent (e.g. Claude Code) triggers `tinyclaw restart` from inside the tmux session, `CLAUDECODE=1` leaks into the new daemon. The queue processor inherits it, and every `claude` invocation fails with "cannot be launched inside another Claude Code session" — silently breaking all agent responses.
- Strips `CLAUDECODE` at the top of `start_daemon()` so the daemon tree always starts clean regardless of how the start was triggered.

## Test plan

- [ ] Start tinyclaw normally — verify no regression
- [ ] From inside a Claude Code session, run `tinyclaw restart` — verify the restarted daemon can spawn `claude` without the nested session error
- [ ] Verify `tinyclaw send "test"` works after an agent-triggered restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)