### PR TITLE
feat: stream tool activity to Telegram in real time

### DIFF
--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -1,10 +1,351 @@
 import { spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { AgentConfig, TeamConfig } from './types';
 import { SCRIPT_DIR, resolveClaudeModel, resolveCodexModel } from './config';
 import { log } from './logging';
 import { ensureAgentDirectory, updateAgentTeammates } from './agent-setup';
+
+type JsonObject = Record<string, unknown>;
+type ActivityCallback = (activity: string) => void;
+
+export interface AgentInvokeResult {
+    text: string;
+    sessionId?: string;
+}
+
+function isObject(value: unknown): value is JsonObject {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toObject(value: unknown): JsonObject | null {
+    return isObject(value) ? value : null;
+}
+
+function getString(value: unknown): string | null {
+    return typeof value === 'string' ? value : null;
+}
+
+function getArray(value: unknown): unknown[] {
+    return Array.isArray(value) ? value : [];
+}
+
+function truncateText(text: string, maxLength = 120): string {
+    if (text.length <= maxLength) {
+        return text;
+    }
+    return `${text.slice(0, maxLength - 3)}...`;
+}
+
+function pickInputString(input: JsonObject, keys: string[]): string | null {
+    for (const key of keys) {
+        const value = getString(input[key]);
+        if (value && value.trim()) {
+            return value.trim();
+        }
+    }
+    return null;
+}
+
+function summarizeToolUse(toolName: string, input: JsonObject | null): string {
+    const normalized = toolName.trim();
+    const lower = normalized.toLowerCase();
+    const safeInput = input || {};
+
+    if (lower === 'read') {
+        const filePath = pickInputString(safeInput, ['file_path', 'path', 'file']);
+        return filePath ? `Read ${truncateText(filePath, 90)}` : 'Read a file';
+    }
+    if (lower === 'write') {
+        const filePath = pickInputString(safeInput, ['file_path', 'path', 'file']);
+        return filePath ? `Wrote ${truncateText(filePath, 90)}` : 'Wrote a file';
+    }
+    if (lower === 'edit') {
+        const filePath = pickInputString(safeInput, ['file_path', 'path', 'file']);
+        return filePath ? `Edited ${truncateText(filePath, 90)}` : 'Edited a file';
+    }
+    if (lower === 'bash') {
+        const command = pickInputString(safeInput, ['command', 'cmd']);
+        return command ? `Ran ${truncateText(command, 90)}` : 'Ran a shell command';
+    }
+    if (lower === 'grep') {
+        const pattern = pickInputString(safeInput, ['pattern', 'query']);
+        return pattern ? `Searched for "${truncateText(pattern, 70)}"` : 'Searched with grep';
+    }
+    if (lower === 'glob') {
+        const pattern = pickInputString(safeInput, ['pattern']);
+        return pattern ? `Matched files with "${truncateText(pattern, 70)}"` : 'Matched files';
+    }
+    if (lower === 'webfetch') {
+        const url = pickInputString(safeInput, ['url']);
+        return url ? `Fetched ${truncateText(url, 90)}` : 'Fetched a URL';
+    }
+    if (lower === 'websearch') {
+        const query = pickInputString(safeInput, ['query']);
+        return query ? `Searched web for "${truncateText(query, 70)}"` : 'Searched the web';
+    }
+
+    return `Used ${normalized || 'a tool'}`;
+}
+
+function recordActivity(
+    summary: string,
+    seenActivities: Set<string>,
+    onActivity?: ActivityCallback,
+    collectedActivities?: string[],
+    dedupe = true
+): void {
+    const trimmed = summary.trim();
+    if (!trimmed) {
+        return;
+    }
+    if (dedupe && seenActivities.has(trimmed)) {
+        return;
+    }
+    if (dedupe) {
+        seenActivities.add(trimmed);
+    }
+    if (collectedActivities) {
+        collectedActivities.push(trimmed);
+    }
+    if (onActivity) {
+        try {
+            onActivity(trimmed);
+        } catch {
+            // Ignore callback failures
+        }
+    }
+}
+
+function processClaudeEvent(
+    eventObj: JsonObject,
+    seenActivities: Set<string>,
+    toolSummaryById: Map<string, string>,
+    onActivity?: ActivityCallback,
+    collectedActivities?: string[]
+): string {
+    let latestResponse = '';
+    const eventType = getString(eventObj.type) || '';
+    const eventSubtype = getString(eventObj.subtype) || '';
+
+    if (eventType === 'result') {
+        const resultText = getString(eventObj.result);
+        if (resultText && resultText.trim()) {
+            latestResponse = resultText.trim();
+        }
+    }
+
+    if (eventType === 'assistant') {
+        const messageObj = toObject(eventObj.message);
+        const contentBlocks = getArray(messageObj?.content);
+        for (const block of contentBlocks) {
+            const blockObj = toObject(block);
+            if (!blockObj) {
+                continue;
+            }
+
+            const blockType = getString(blockObj.type) || '';
+            if (blockType === 'text') {
+                const text = getString(blockObj.text);
+                if (text && text.trim()) {
+                    latestResponse = text.trim();
+                }
+            }
+            if (blockType === 'tool_use') {
+                const toolName = getString(blockObj.name) || 'tool';
+                const summary = summarizeToolUse(toolName, toObject(blockObj.input));
+                const toolUseId = getString(blockObj.id);
+                if (toolUseId) {
+                    toolSummaryById.set(toolUseId, summary);
+                }
+                recordActivity(summary, seenActivities, onActivity, collectedActivities, true);
+            }
+        }
+    }
+
+    if (eventType === 'user') {
+        const messageObj = toObject(eventObj.message);
+        const contentBlocks = getArray(messageObj?.content);
+        for (const block of contentBlocks) {
+            const blockObj = toObject(block);
+            if (!blockObj) {
+                continue;
+            }
+            if ((getString(blockObj.type) || '') !== 'tool_result') {
+                continue;
+            }
+            const toolUseId = getString(blockObj.tool_use_id) || '';
+            const priorSummary = toolSummaryById.get(toolUseId);
+            const completion = priorSummary
+                ? `Completed ${priorSummary.toLowerCase()}`
+                : 'Tool result received';
+            // Tool results should stream even if text repeats.
+            recordActivity(completion, seenActivities, onActivity, collectedActivities, false);
+        }
+    }
+
+    if (eventType.includes('tool') || eventSubtype.includes('tool')) {
+        const toolName = getString(eventObj.tool_name)
+            || getString(eventObj.name)
+            || getString(toObject(eventObj.tool)?.name)
+            || 'tool';
+        const input = toObject(eventObj.input) || toObject(eventObj.arguments) || toObject(eventObj.tool_input);
+        const summary = summarizeToolUse(toolName, input);
+        recordActivity(summary, seenActivities, onActivity, collectedActivities, true);
+    }
+
+    return latestResponse;
+}
+
+function parseSessionId(value: unknown): string | null {
+    const raw = getString(value);
+    if (!raw) return null;
+    const trimmed = raw.trim();
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(trimmed)
+        ? trimmed
+        : null;
+}
+
+function tryExtractSessionId(eventObj: JsonObject): string | null {
+    const direct = parseSessionId(eventObj.sessionId) || parseSessionId(eventObj.session_id);
+    if (direct) return direct;
+
+    const messageObj = toObject(eventObj.message);
+    const fromMessage = messageObj
+        ? (parseSessionId(messageObj.sessionId) || parseSessionId(messageObj.session_id))
+        : null;
+    if (fromMessage) return fromMessage;
+
+    const payload = toObject(eventObj.payload);
+    if (!payload) return null;
+    return parseSessionId(payload.sessionId) || parseSessionId(payload.session_id);
+}
+
+function getLatestClaudeSessionId(workingDir: string): string | undefined {
+    try {
+        const projectKey = workingDir.replace(/\//g, '-');
+        const projectDir = path.join(os.homedir(), '.claude', 'projects', projectKey);
+        if (!fs.existsSync(projectDir)) return undefined;
+
+        const latest = fs.readdirSync(projectDir)
+            .filter(name => name.endsWith('.jsonl'))
+            .map(name => {
+                const fullPath = path.join(projectDir, name);
+                return { name, mtimeMs: fs.statSync(fullPath).mtimeMs };
+            })
+            .sort((a, b) => b.mtimeMs - a.mtimeMs)[0];
+
+        if (!latest) return undefined;
+        return latest.name.replace(/\.jsonl$/, '');
+    } catch {
+        return undefined;
+    }
+}
+
+async function runClaudeCommand(
+    args: string[],
+    cwd: string,
+    onActivity?: ActivityCallback
+): Promise<{ output: string; parsed: { response: string; activities: string[] }; sessionId?: string }> {
+    return new Promise((resolve, reject) => {
+        const child = spawn('claude', args, {
+            cwd,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let stdoutBuffer = '';
+        let stderrBuffer = '';
+        let finalResponse = '';
+        let sessionId: string | undefined;
+        const activities: string[] = [];
+        const seenActivities = new Set<string>();
+        const toolSummaryById = new Map<string, string>();
+
+        function processLine(line: string): void {
+            const trimmed = line.trim();
+            if (!trimmed) {
+                return;
+            }
+            let event: unknown;
+            try {
+                event = JSON.parse(trimmed);
+            } catch {
+                return;
+            }
+            const eventObj = toObject(event);
+            if (!eventObj) {
+                return;
+            }
+            const extractedSessionId = tryExtractSessionId(eventObj);
+            if (extractedSessionId) {
+                sessionId = extractedSessionId;
+            }
+            const responseUpdate = processClaudeEvent(eventObj, seenActivities, toolSummaryById, onActivity, activities);
+            if (responseUpdate) {
+                finalResponse = responseUpdate;
+            }
+        }
+
+        function consumeChunk(chunk: string, isStdout: boolean): void {
+            if (isStdout) {
+                stdout += chunk;
+                stdoutBuffer += chunk;
+                while (stdoutBuffer.includes('\n')) {
+                    const idx = stdoutBuffer.indexOf('\n');
+                    const line = stdoutBuffer.slice(0, idx);
+                    stdoutBuffer = stdoutBuffer.slice(idx + 1);
+                    processLine(line);
+                }
+            } else {
+                stderr += chunk;
+                stderrBuffer += chunk;
+                while (stderrBuffer.includes('\n')) {
+                    const idx = stderrBuffer.indexOf('\n');
+                    const line = stderrBuffer.slice(0, idx);
+                    stderrBuffer = stderrBuffer.slice(idx + 1);
+                    processLine(line);
+                }
+            }
+        }
+
+        child.stdout.setEncoding('utf8');
+        child.stderr.setEncoding('utf8');
+
+        child.stdout.on('data', (chunk: string) => consumeChunk(chunk, true));
+        child.stderr.on('data', (chunk: string) => consumeChunk(chunk, false));
+
+        child.on('error', (error) => {
+            reject(error);
+        });
+
+        child.on('close', (code) => {
+            if (stdoutBuffer.trim()) {
+                processLine(stdoutBuffer);
+            }
+            if (stderrBuffer.trim()) {
+                processLine(stderrBuffer);
+            }
+
+            if (code === 0) {
+                resolve({
+                    output: stdout,
+                    parsed: {
+                        response: finalResponse,
+                        activities: activities.slice(0, 20),
+                    },
+                    sessionId,
+                });
+                return;
+            }
+
+            const errorMessage = stderr.trim() || stdout.trim() || `Command exited with code ${code}`;
+            reject(new Error(errorMessage));
+        });
+    });
+}
 
 export async function runCommand(command: string, args: string[], cwd?: string): Promise<string> {
     return new Promise((resolve, reject) => {
@@ -45,7 +386,7 @@ export async function runCommand(command: string, args: string[], cwd?: string):
 
 /**
  * Invoke a single agent with a message. Contains all Claude/Codex invocation logic.
- * Returns the raw response text.
+ * Returns the response text and optional session ID.
  */
 export async function invokeAgent(
     agent: AgentConfig,
@@ -54,8 +395,9 @@ export async function invokeAgent(
     workspacePath: string,
     shouldReset: boolean,
     agents: Record<string, AgentConfig> = {},
-    teams: Record<string, TeamConfig> = {}
-): Promise<string> {
+    teams: Record<string, TeamConfig> = {},
+    options?: { onActivity?: ActivityCallback }
+): Promise<AgentInvokeResult> {
     // Ensure agent directory exists with config files
     const agentDir = path.join(workspacePath, agentId);
     const isNewAgent = !fs.existsSync(agentDir);
@@ -111,7 +453,9 @@ export async function invokeAgent(
             }
         }
 
-        return response || 'Sorry, I could not generate a response from Codex.';
+        return {
+            text: response || 'Sorry, I could not generate a response from Codex.',
+        };
     } else {
         // Default to Claude (Anthropic)
         log('INFO', `Using Claude provider (agent: ${agentId})`);
@@ -130,8 +474,29 @@ export async function invokeAgent(
         if (continueConversation) {
             claudeArgs.push('-c');
         }
-        claudeArgs.push('-p', message);
+        claudeArgs.push('--verbose', '--output-format', 'stream-json', '-p', message);
 
-        return await runCommand('claude', claudeArgs, workingDir);
+        const runResult = await runClaudeCommand(claudeArgs, workingDir, options?.onActivity);
+        const parsed = runResult.parsed;
+        const hasActivities = parsed.activities.length > 0;
+        const hasResponse = parsed.response.trim().length > 0;
+
+        if (hasActivities && hasResponse && !options?.onActivity) {
+            const activityLines = parsed.activities.map(item => `- ${item}`).join('\n');
+            return {
+                text: `Activity:\n${activityLines}\n\n${parsed.response}`,
+                sessionId: runResult.sessionId || getLatestClaudeSessionId(workingDir),
+            };
+        }
+        if (hasActivities && !options?.onActivity) {
+            return {
+                text: `Activity:\n${parsed.activities.map(item => `- ${item}`).join('\n')}`,
+                sessionId: runResult.sessionId || getLatestClaudeSessionId(workingDir),
+            };
+        }
+        return {
+            text: parsed.response || 'Sorry, I could not generate a response from Claude.',
+            sessionId: runResult.sessionId || getLatestClaudeSessionId(workingDir),
+        };
     }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export interface TeamConfig {
 export interface ChainStep {
     agentId: string;
     response: string;
+    sessionId?: string;
 }
 
 export interface Settings {
@@ -83,6 +84,9 @@ export interface ResponseData {
     messageId: string;
     agent?: string; // which agent handled this
     files?: string[];
+    sessionId?: string;
+    partial?: boolean;
+    updateType?: 'activity' | 'final';
 }
 
 export interface QueueFile {


### PR DESCRIPTION
## Summary

- When an agent uses tools (Read, Write, Bash, Grep, etc.), Telegram users now see live updates like "Read /src/index.ts" and "Ran npm test" as the agent works, instead of waiting silently for the final response
- Claude CLI is invoked with `--output-format stream-json` and stdout is parsed line-by-line in real time to detect `tool_use` events
- Activity summaries are sent as partial responses to the Telegram outgoing queue, which the Telegram client delivers immediately while keeping the conversation pending until the final response arrives

## Changes

### `src/lib/invoke.ts` (main change)
- Added `runClaudeCommand()` which spawns the Claude CLI and streams JSONL events in real time
- Added `summarizeToolUse()` to turn raw tool calls into readable strings (e.g. `Read /src/index.ts`, `Ran npm test`, `Searched for "handleClick"`)
- Added `processClaudeEvent()` to parse streaming events and detect tool_use/tool_result blocks
- `invokeAgent()` now accepts an `onActivity` callback, returns `AgentInvokeResult` (text + sessionId) instead of a plain string
- Session ID extraction from streaming events for conversation continuity

### `src/queue-processor.ts`
- Added `writeResponse()` helper that supports `partial`, `updateType`, and `sessionId` fields
- Added `activityEmitterForAgent()` — creates a callback that writes partial activity responses to the outgoing queue when tools fire
- Activity streaming is enabled for Telegram channel messages (`streamActivitiesEnabled = channel === 'telegram'`)

### `src/channels/telegram-client.ts`
- `ResponseData` interface extended with `sessionId`, `partial`, `updateType`
- Outgoing queue files are now sorted for consistent ordering
- Partial (activity) responses are sent immediately but **do not** clear pending state — only the final response does
- Session ID appended to final responses

### `src/lib/types.ts`
- `ResponseData`: added `sessionId?`, `partial?`, `updateType?` fields
- `ChainStep`: added `sessionId?` field

## Test plan

- [ ] Send a message to the Telegram bot that triggers tool use (e.g. ask the agent to read a file or run a command)
- [ ] Verify that activity messages appear in Telegram as tools are called (e.g. "Read /path/to/file")
- [ ] Verify the final response still arrives normally after activities
- [ ] Verify non-Telegram channels (Discord, WhatsApp) continue to work without activity streaming
- [ ] Verify team chain conversations still work with activity streaming enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)