### PR TITLE
fix(heartbeat): escape agent heartbeat.md contents when queuing messages

### DIFF
--- a/lib/heartbeat-cron.sh
+++ b/lib/heartbeat-cron.sh
@@ -82,16 +82,20 @@ while true; do
         MESSAGE_ID="heartbeat_${AGENT_ID}_$(date +%s)_$$"
 
         # Write to queue with @agent_id routing prefix
-        cat > "$QUEUE_INCOMING/${MESSAGE_ID}.json" << EOF
-{
-  "channel": "heartbeat",
-  "sender": "System",
-  "senderId": "heartbeat_${AGENT_ID}",
-  "message": "@${AGENT_ID} ${PROMPT}",
-  "timestamp": $(date +%s)000,
-  "messageId": "$MESSAGE_ID"
-}
-EOF
+        TIMESTAMP="$(date +%s)000"
+        jq -n \
+            --arg message "@${AGENT_ID} ${PROMPT}" \
+            --arg senderId "heartbeat_${AGENT_ID}" \
+            --argjson timestamp "$TIMESTAMP" \
+            --arg messageId "$MESSAGE_ID" \
+            '{
+                channel: "heartbeat",
+                sender: "System",
+                senderId: $senderId,
+                message: $message,
+                timestamp: $timestamp,
+                messageId: $messageId
+            }' > "$QUEUE_INCOMING/${MESSAGE_ID}.json"
 
         log "  ✓ Queued for @$AGENT_ID: $MESSAGE_ID"
     done


### PR DESCRIPTION
Messages were getting stuck in the queue and unable to be processed due to them containing malformatted JSON.

This PR fixes this by using `jq` to correctly generate the message JSON files.

Before:

```json
{
  "channel": "heartbeat",
  "sender": "System",
  "senderId": "heartbeat_rex",
  "message": "@rex ## Required TODO Workflow
    <redacted>
 ",
  "timestamp": 1771291011000,
  "messageId": "heartbeat_rex_1771291011_28097"
}
```

After:

```json
{
  "channel": "heartbeat",
  "sender": "System",
  "senderId": "heartbeat_anvil",
  "message": "@anvil ## Required TODO Workflow\n\n1. Check <redacted>",
  "timestamp": 1771291011000,
  "messageId": "heartbeat_anvil_1771291011_28097"
}

```