### PR TITLE
fix: preserve slashes in workspace name input

### DIFF
--- a/lib/setup-wizard.sh
+++ b/lib/setup-wizard.sh
@@ -208,8 +208,12 @@ echo ""
 read -rp "Workspace name [default: tinyclaw-workspace]: " WORKSPACE_INPUT
 WORKSPACE_NAME=${WORKSPACE_INPUT:-tinyclaw-workspace}
 # Clean workspace name
-WORKSPACE_NAME=$(echo "$WORKSPACE_NAME" | tr ' ' '-' | tr -cd 'a-zA-Z0-9_-')
-WORKSPACE_PATH="$HOME/$WORKSPACE_NAME"
+WORKSPACE_NAME=$(echo "$WORKSPACE_NAME" | tr ' ' '-' | tr -cd 'a-zA-Z0-9_/~.-')
+if [[ "$WORKSPACE_NAME" == /* || "$WORKSPACE_NAME" == ~* ]]; then
+  WORKSPACE_PATH="${WORKSPACE_NAME/#\~/$HOME}"
+else
+  WORKSPACE_PATH="$HOME/$WORKSPACE_NAME"
+fi
 echo -e "${GREEN}✓ Workspace: $WORKSPACE_PATH${NC}"
 echo ""
 


### PR DESCRIPTION
## Summary

- Fixes `tr -cd 'a-zA-Z0-9_-'` stripping `/` from workspace name input, causing paths like `Github/personal/tinyclaw-workspace` to become `Githubpersonaltinyclaw-workspace`
- Allows `/`, `~`, and `.` through the sanitizer so relative and absolute paths work
- Treats inputs starting with `/` or `~` as absolute paths (skips `$HOME/` prefix)

Fixes #86

## Test plan

- [x] Run setup wizard, enter a relative subpath like `Github/personal/tinyclaw-workspace` — should resolve to `~/Github/personal/tinyclaw-workspace`
- [x] Enter an absolute path like `/opt/tinyclaw-workspace` — should use it as-is
- [x] Enter a `~`-prefixed path like `~/projects/tinyclaw` — should expand `~` to `$HOME`
- [x] Enter a plain name like `tinyclaw-workspace` — should still resolve to `~/tinyclaw-workspace` (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)