### PR TITLE
fix: use TINYCLAW_HOME for WhatsApp QR and ready file paths

### DIFF
--- a/src/channels/whatsapp-client.ts
+++ b/src/channels/whatsapp-client.ts
@@ -201,7 +201,7 @@ client.on('qr', (qr: string) => {
     qrcode.generate(qr, { small: true });
 
     // Save to file for tinyclaw.sh to display (avoids tmux capture distortion)
-    const channelsDir = path.join(SCRIPT_DIR, '.tinyclaw/channels');
+    const channelsDir = path.join(TINYCLAW_HOME, 'channels');
     if (!fs.existsSync(channelsDir)) {
         fs.mkdirSync(channelsDir, { recursive: true });
     }
@@ -226,7 +226,7 @@ client.on('ready', () => {
     log('INFO', 'Listening for messages...');
 
     // Create ready flag for tinyclaw.sh
-    const readyFile = path.join(SCRIPT_DIR, '.tinyclaw/channels/whatsapp_ready');
+    const readyFile = path.join(TINYCLAW_HOME, 'channels/whatsapp_ready');
     fs.writeFileSync(readyFile, Date.now().toString());
 });
 
@@ -475,7 +475,7 @@ client.on('disconnected', (reason: string) => {
     log('WARN', `WhatsApp disconnected: ${reason}`);
 
     // Remove ready flag
-    const readyFile = path.join(SCRIPT_DIR, '.tinyclaw/channels/whatsapp_ready');
+    const readyFile = path.join(TINYCLAW_HOME, 'channels/whatsapp_ready');
     if (fs.existsSync(readyFile)) {
         fs.unlinkSync(readyFile);
     }
@@ -486,7 +486,7 @@ process.on('SIGINT', async () => {
     log('INFO', 'Shutting down WhatsApp client...');
 
     // Remove ready flag
-    const readyFile = path.join(SCRIPT_DIR, '.tinyclaw/channels/whatsapp_ready');
+    const readyFile = path.join(TINYCLAW_HOME, 'channels/whatsapp_ready');
     if (fs.existsSync(readyFile)) {
         fs.unlinkSync(readyFile);
     }
@@ -499,7 +499,7 @@ process.on('SIGTERM', async () => {
     log('INFO', 'Shutting down WhatsApp client...');
 
     // Remove ready flag
-    const readyFile = path.join(SCRIPT_DIR, '.tinyclaw/channels/whatsapp_ready');
+    const readyFile = path.join(TINYCLAW_HOME, 'channels/whatsapp_ready');
     if (fs.existsSync(readyFile)) {
         fs.unlinkSync(readyFile);
     }


### PR DESCRIPTION
## Summary

- WhatsApp QR code and ready flag files were written to `SCRIPT_DIR/.tinyclaw/channels/` (project root) while `daemon.sh` polled `$TINYCLAW_HOME/channels/` (`~/.tinyclaw/channels/`)
- This path mismatch caused the setup wizard to hang at "Starting WhatsApp client..." without ever displaying the QR code
- Replaced all 5 occurrences of `SCRIPT_DIR` with `TINYCLAW_HOME` for the `channels/` directory in `whatsapp-client.ts`

## Test plan

- [ ] Run `tinyclaw setup` and configure WhatsApp as a channel
- [ ] Start tinyclaw — QR code should display in the terminal within ~10s
- [ ] Scan the QR code — wizard should detect connection and show "WhatsApp connected and ready!"
- [ ] Restart tinyclaw — should reconnect using saved session without requiring a new QR scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)