### PR TITLE
feat: add Avian AI provider

### DIFF
--- a/lib/setup-wizard.sh
+++ b/lib/setup-wizard.sh
@@ -84,13 +84,15 @@ echo ""
 echo "  1) Anthropic (Claude)  (recommended)"
 echo "  2) OpenAI (Codex/GPT)"
 echo "  3) OpenCode"
+echo "  4) Avian"
 echo ""
-read -rp "Choose [1-3]: " PROVIDER_CHOICE
+read -rp "Choose [1-4]: " PROVIDER_CHOICE
 
 case "$PROVIDER_CHOICE" in
     1) PROVIDER="anthropic" ;;
     2) PROVIDER="openai" ;;
     3) PROVIDER="opencode" ;;
+    4) PROVIDER="avian" ;;
     *)
         echo -e "${RED}Invalid choice${NC}"
         exit 1
@@ -123,6 +125,32 @@ if [ "$PROVIDER" = "anthropic" ]; then
             echo -e "${RED}Invalid choice${NC}"
             exit 1
             ;;
+    esac
+    echo -e "${GREEN}✓ Model: $MODEL${NC}"
+    echo ""
+elif [ "$PROVIDER" = "avian" ]; then
+    echo "Which Avian model?"
+    echo ""
+    echo "  1) deepseek/deepseek-v3.2  (recommended)"
+    echo "  2) moonshotai/kimi-k2.5"
+    echo "  3) z-ai/glm-5"
+    echo "  4) minimax/minimax-m2.5"
+    echo "  5) Custom  (enter model name)"
+    echo ""
+    read -rp "Choose [1-5, default: 1]: " MODEL_CHOICE
+
+    case "$MODEL_CHOICE" in
+        2) MODEL="moonshotai/kimi-k2.5" ;;
+        3) MODEL="z-ai/glm-5" ;;
+        4) MODEL="minimax/minimax-m2.5" ;;
+        5)
+            read -rp "Enter model name: " MODEL
+            if [ -z "$MODEL" ]; then
+                echo -e "${RED}Model name required${NC}"
+                exit 1
+            fi
+            ;;
+        *) MODEL="deepseek/deepseek-v3.2" ;;
     esac
     echo -e "${GREEN}✓ Model: $MODEL${NC}"
     echo ""
@@ -270,15 +298,26 @@ if [[ "$SETUP_AGENTS" =~ ^[yY] ]]; then
         read -rp "  Display name: " NEW_AGENT_NAME
         [ -z "$NEW_AGENT_NAME" ] && NEW_AGENT_NAME="$NEW_AGENT_ID"
 
-        echo "  Provider: 1) Anthropic  2) OpenAI  3) OpenCode"
-        read -rp "  Choose [1-3, default: 1]: " NEW_PROVIDER_CHOICE
+        echo "  Provider: 1) Anthropic  2) OpenAI  3) OpenCode  4) Avian"
+        read -rp "  Choose [1-4, default: 1]: " NEW_PROVIDER_CHOICE
         case "$NEW_PROVIDER_CHOICE" in
             2) NEW_PROVIDER="openai" ;;
             3) NEW_PROVIDER="opencode" ;;
+            4) NEW_PROVIDER="avian" ;;
             *) NEW_PROVIDER="anthropic" ;;
         esac
 
-        if [ "$NEW_PROVIDER" = "anthropic" ]; then
+        if [ "$NEW_PROVIDER" = "avian" ]; then
+            echo "  Model: 1) deepseek/deepseek-v3.2  2) moonshotai/kimi-k2.5  3) z-ai/glm-5  4) minimax/minimax-m2.5  5) Custom"
+            read -rp "  Choose [1-5, default: 1]: " NEW_MODEL_CHOICE
+            case "$NEW_MODEL_CHOICE" in
+                2) NEW_MODEL="moonshotai/kimi-k2.5" ;;
+                3) NEW_MODEL="z-ai/glm-5" ;;
+                4) NEW_MODEL="minimax/minimax-m2.5" ;;
+                5) read -rp "  Enter model name: " NEW_MODEL ;;
+                *) NEW_MODEL="deepseek/deepseek-v3.2" ;;
+            esac
+        elif [ "$NEW_PROVIDER" = "anthropic" ]; then
             echo "  Model: 1) Sonnet  2) Opus  3) Custom"
             read -rp "  Choose [1-3, default: 1]: " NEW_MODEL_CHOICE
             case "$NEW_MODEL_CHOICE" in
@@ -339,6 +378,8 @@ if [ "$PROVIDER" = "anthropic" ]; then
     MODELS_SECTION='"models": { "provider": "anthropic", "anthropic": { "model": "'"${MODEL}"'" } }'
 elif [ "$PROVIDER" = "opencode" ]; then
     MODELS_SECTION='"models": { "provider": "opencode", "opencode": { "model": "'"${MODEL}"'" } }'
+elif [ "$PROVIDER" = "avian" ]; then
+    MODELS_SECTION='"models": { "provider": "avian", "avian": { "model": "'"${MODEL}"'" } }'
 else
     MODELS_SECTION='"models": { "provider": "openai", "openai": { "model": "'"${MODEL}"'" } }'
 fi

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { jsonrepair } from 'jsonrepair';
-import { Settings, AgentConfig, TeamConfig, CLAUDE_MODEL_IDS, CODEX_MODEL_IDS, OPENCODE_MODEL_IDS } from './types';
+import { Settings, AgentConfig, TeamConfig, CLAUDE_MODEL_IDS, CODEX_MODEL_IDS, OPENCODE_MODEL_IDS, AVIAN_MODEL_IDS } from './types';
 
 export const SCRIPT_DIR = path.resolve(__dirname, '../..');
 const _localTinyclaw = path.join(SCRIPT_DIR, '.tinyclaw');
@@ -48,6 +48,9 @@ export function getSettings(): Settings {
             } else if (settings?.models?.opencode) {
                 if (!settings.models) settings.models = {};
                 settings.models.provider = 'opencode';
+            } else if (settings?.models?.avian) {
+                if (!settings.models) settings.models = {};
+                settings.models.provider = 'avian';
             } else if (settings?.models?.anthropic) {
                 if (!settings.models) settings.models = {};
                 settings.models.provider = 'anthropic';
@@ -71,6 +74,8 @@ export function getDefaultAgentFromModels(settings: Settings): AgentConfig {
         model = settings?.models?.openai?.model || 'gpt-5.3-codex';
     } else if (provider === 'opencode') {
         model = settings?.models?.opencode?.model || 'sonnet';
+    } else if (provider === 'avian') {
+        model = settings?.models?.avian?.model || 'deepseek/deepseek-v3.2';
     } else {
         model = settings?.models?.anthropic?.model || 'sonnet';
     }
@@ -126,4 +131,12 @@ export function resolveCodexModel(model: string): string {
  */
 export function resolveOpenCodeModel(model: string): string {
     return OPENCODE_MODEL_IDS[model] || model || '';
+}
+
+/**
+ * Resolve the model ID for Avian (OpenAI-compatible API).
+ * Falls back to the raw model string from settings if no mapping is found.
+ */
+export function resolveAvianModel(model: string): string {
+    return AVIAN_MODEL_IDS[model] || model || '';
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,7 @@
 export interface AgentConfig {
     name: string;
-    provider: string;       // 'anthropic', 'openai', or 'opencode'
-    model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex'
+    provider: string;       // 'anthropic', 'openai', 'opencode', or 'avian'
+    model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex', 'deepseek/deepseek-v3.2'
     working_directory: string;
     system_prompt?: string;
     prompt_file?: string;
@@ -43,7 +43,7 @@ export interface Settings {
         whatsapp?: {};
     };
     models?: {
-        provider?: string; // 'anthropic', 'openai', or 'opencode'
+        provider?: string; // 'anthropic', 'openai', 'opencode', or 'avian'
         anthropic?: {
             model?: string;
         };
@@ -51,6 +51,9 @@ export interface Settings {
             model?: string;
         };
         opencode?: {
+            model?: string;
+        };
+        avian?: {
             model?: string;
         };
     };
@@ -114,6 +117,19 @@ export const CLAUDE_MODEL_IDS: Record<string, string> = {
 export const CODEX_MODEL_IDS: Record<string, string> = {
     'gpt-5.2': 'gpt-5.2',
     'gpt-5.3-codex': 'gpt-5.3-codex',
+};
+
+// Avian model IDs (OpenAI-compatible API at https://api.avian.io/v1).
+// Uses AVIAN_API_KEY env var for authentication.
+export const AVIAN_MODEL_IDS: Record<string, string> = {
+    'deepseek-v3.2': 'deepseek/deepseek-v3.2',
+    'deepseek/deepseek-v3.2': 'deepseek/deepseek-v3.2',
+    'kimi-k2.5': 'moonshotai/kimi-k2.5',
+    'moonshotai/kimi-k2.5': 'moonshotai/kimi-k2.5',
+    'glm-5': 'z-ai/glm-5',
+    'z-ai/glm-5': 'z-ai/glm-5',
+    'minimax-m2.5': 'minimax/minimax-m2.5',
+    'minimax/minimax-m2.5': 'minimax/minimax-m2.5',
 };
 
 // OpenCode model IDs in provider/model format (passed via --model / -m flag).

--- a/src/queue-processor.ts
+++ b/src/queue-processor.ts
@@ -162,7 +162,7 @@ async function processMessage(dbMsg: DbMessage): Promise<void> {
             response = await invokeAgent(agent, agentId, message, workspacePath, shouldReset, agents, teams);
         } catch (error) {
             const provider = agent.provider || 'anthropic';
-            const providerLabel = provider === 'openai' ? 'Codex' : provider === 'opencode' ? 'OpenCode' : 'Claude';
+            const providerLabel = provider === 'openai' ? 'Codex' : provider === 'opencode' ? 'OpenCode' : provider === 'avian' ? 'Avian' : 'Claude';
             log('ERROR', `${providerLabel} error (agent: ${agentId}): ${(error as Error).message}`);
             response = "Sorry, I encountered an error processing your request. Please check the queue logs.";
         }

--- a/tinyoffice/src/app/agents/page.tsx
+++ b/tinyoffice/src/app/agents/page.tsx
@@ -212,6 +212,7 @@ function AgentEditor({
               <option value="anthropic">anthropic</option>
               <option value="openai">openai</option>
               <option value="opencode">opencode</option>
+              <option value="avian">avian</option>
             </Select>
           </div>
           <div className="space-y-1.5">
@@ -287,6 +288,7 @@ function AgentCard({
     anthropic: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
     openai: "bg-green-500/10 text-green-600 dark:text-green-400",
     opencode: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    avian: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
   };
 
   return (


### PR DESCRIPTION
## Summary

Adds [Avian](https://avian.io) as a new AI provider alongside Anthropic, OpenAI, and OpenCode. Avian exposes an OpenAI-compatible API, so the invocation uses native `fetch()` to call `https://api.avian.io/v1/chat/completions` with Bearer token auth via `AVIAN_API_KEY`.

**Available models:**
- `deepseek/deepseek-v3.2` (164K context, 65K output) — default
- `moonshotai/kimi-k2.5` (131K context, 8K output)
- `z-ai/glm-5` (131K context, 16K output)
- `minimax/minimax-m2.5` (1M context, 1M output)

**Supports:** chat completions, streaming, function calling/tools

## Changes

Follows the exact same pattern as the OpenCode provider addition (PR #60):

- **`src/lib/types.ts`** — `AVIAN_MODEL_IDS` mapping, `Settings.models.avian` interface
- **`src/lib/config.ts`** — Auto-detect avian provider, `resolveAvianModel()`, default model fallback
- **`src/lib/invoke.ts`** — HTTP invocation via `fetch()` to OpenAI-compatible chat completions endpoint
- **`src/queue-processor.ts`** — Error label for Avian provider
- **`lib/setup-wizard.sh`** — Provider and model selection menus (setup + additional agents)
- **`lib/agents.sh`** — `agent add` and `agent provider` commands
- **`tinyclaw.sh`** — Global `provider` and `model` commands
- **`tinyoffice/src/app/agents/page.tsx`** — Dropdown option + purple badge color

## Usage

```bash
# Set API key
export AVIAN_API_KEY=your-key-here

# Via setup wizard
tinyclaw setup  # Select option 4) Avian

# Switch existing installation
tinyclaw provider avian --model deepseek/deepseek-v3.2

# Per-agent
tinyclaw agent provider coder avian --model moonshotai/kimi-k2.5
```

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` passes with zero errors)
- [ ] Setup wizard shows Avian as option 4 and lists models
- [ ] `tinyclaw provider avian` switches provider in settings.json
- [ ] `tinyclaw model deepseek/deepseek-v3.2` sets model correctly
- [ ] Agent add flow includes Avian provider and model choices
- [ ] TinyOffice agents page shows Avian in provider dropdown
- [ ] With `AVIAN_API_KEY` set, messages routed to Avian agent get API responses

cc @jlia0