### PR TITLE
feat: support team member management and cleanup team references on agent removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,15 @@ Commands work with `tinyclaw` (if CLI installed) or `./tinyclaw.sh` (direct scri
 
 ### Team Commands
 
-| Command               | Description                        | Example                       |
-| --------------------- | ---------------------------------- | ----------------------------- |
-| `team list`           | List all configured teams          | `tinyclaw team list`          |
-| `team add`            | Add new team (interactive)         | `tinyclaw team add`           |
-| `team show <id>`      | Show team configuration            | `tinyclaw team show dev`      |
-| `team remove <id>`    | Remove a team                      | `tinyclaw team remove dev`    |
-| `team visualize [id]` | Live TUI dashboard for team chains | `tinyclaw team visualize dev` |
+| Command                     | Description                        | Example                                   |
+| --------------------------- | ---------------------------------- | ----------------------------------------- |
+| `team list`                 | List all configured teams          | `tinyclaw team list`                      |
+| `team add`                  | Add new team (interactive)         | `tinyclaw team add`                       |
+| `team show <id>`            | Show team configuration            | `tinyclaw team show dev`                  |
+| `team remove <id>`          | Remove a team                      | `tinyclaw team remove dev`                |
+| `team add-agent <t> <a>`    | Add an existing agent to a team    | `tinyclaw team add-agent dev reviewer`    |
+| `team remove-agent <t> <a>` | Remove an agent from a team        | `tinyclaw team remove-agent dev reviewer` |
+| `team visualize [id]`       | Live TUI dashboard for team chains | `tinyclaw team visualize dev`             |
 
 ### Configuration Commands
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -641,6 +641,8 @@ tinyclaw team list                # List all teams
 tinyclaw team add                 # Add a new team (interactive)
 tinyclaw team show dev            # Show team configuration
 tinyclaw team remove dev          # Remove a team
+tinyclaw team add-agent dev reviewer     # Add an existing agent to a team
+tinyclaw team remove-agent dev reviewer  # Remove an agent from a team
 ```
 
 **In-chat Commands:**

--- a/docs/TEAMS.md
+++ b/docs/TEAMS.md
@@ -160,6 +160,8 @@ tinyclaw team list              # List all teams
 tinyclaw team add               # Add a new team (interactive wizard)
 tinyclaw team show dev          # Show team configuration
 tinyclaw team remove dev        # Remove a team
+tinyclaw team add-agent dev reviewer     # Add @reviewer to @dev
+tinyclaw team remove-agent dev reviewer  # Remove @reviewer from @dev
 tinyclaw team visualize [id]    # Live TUI dashboard
 ```
 

--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -306,6 +306,10 @@ agent_remove() {
         exit 1
     fi
 
+    # Load settings to get workspace path for cleanup.
+    load_settings
+    AGENTS_DIR="$WORKSPACE_PATH"
+
     local agent_json
     agent_json=$(jq -r "(.agents // {}).\"${agent_id}\" // empty" "$SETTINGS_FILE" 2>/dev/null)
 
@@ -317,6 +321,29 @@ agent_remove() {
     local agent_name
     agent_name=$(jq -r "(.agents // {}).\"${agent_id}\".name" "$SETTINGS_FILE" 2>/dev/null)
 
+    # Find all teams that currently include this agent.
+    local member_teams=()
+    local member_team_names=()
+    while IFS='|' read -r tid tname; do
+        [ -z "$tid" ] && continue
+        member_teams+=("$tid")
+        member_team_names+=("$tname")
+    done < <(jq -r --arg aid "$agent_id" \
+        '(.teams // {}) | to_entries[] | select(.value.agents | index($aid)) | "\(.key)|\(.value.name)"' \
+        "$SETTINGS_FILE" 2>/dev/null)
+
+    if [ ${#member_teams[@]} -gt 0 ]; then
+        echo -e "${YELLOW}Agent '${agent_id}' is in ${#member_teams[@]} team(s):${NC}"
+        local i
+        for i in "${!member_teams[@]}"; do
+            echo "  @${member_teams[$i]} - ${member_team_names[$i]}"
+        done
+        echo ""
+        echo "Continuing will remove this agent from those teams as well."
+        echo "If this agent is a team leader, a new leader will be auto-selected."
+        echo "If a team becomes empty, that team will be removed."
+    fi
+
     read -rp "Remove agent '${agent_id}' (${agent_name})? [y/N]: " CONFIRM
     if [[ ! "$CONFIRM" =~ ^[yY] ]]; then
         echo "Cancelled."
@@ -326,12 +353,92 @@ agent_remove() {
     local tmp_file="$SETTINGS_FILE.tmp"
     jq --arg id "$agent_id" 'del(.agents[$id])' "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
 
+    # Also remove this agent from any teams and keep team leaders valid.
+    local removed_from_teams=()
+    local removed_empty_teams=()
+    local reassigned_leaders=()
+    if [ ${#member_teams[@]} -gt 0 ]; then
+        local team_id
+        for team_id in "${member_teams[@]}"; do
+            # Team may already have been removed by an earlier iteration.
+            local team_exists
+            team_exists=$(jq -r --arg tid "$team_id" 'if ((.teams // {})[$tid]) then "yes" else "no" end' "$SETTINGS_FILE" 2>/dev/null)
+            if [ "$team_exists" != "yes" ]; then
+                continue
+            fi
+
+            local remaining_count
+            remaining_count=$(jq -r --arg tid "$team_id" --arg aid "$agent_id" \
+                '(((.teams // {})[$tid].agents // []) | map(select(. != $aid)) | length)' \
+                "$SETTINGS_FILE" 2>/dev/null)
+
+            if [ "$remaining_count" -lt 1 ]; then
+                jq --arg tid "$team_id" 'del(.teams[$tid])' "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                removed_empty_teams+=("$team_id")
+                continue
+            fi
+
+            local current_leader
+            current_leader=$(jq -r --arg tid "$team_id" '(.teams // {})[$tid].leader_agent // empty' "$SETTINGS_FILE" 2>/dev/null)
+            local new_leader="$current_leader"
+            if [ "$current_leader" = "$agent_id" ] || [ -z "$current_leader" ]; then
+                new_leader=$(jq -r --arg tid "$team_id" --arg aid "$agent_id" \
+                    '(((.teams // {})[$tid].agents // []) | map(select(. != $aid)) | .[0]) // empty' \
+                    "$SETTINGS_FILE" 2>/dev/null)
+            fi
+
+            jq --arg tid "$team_id" --arg aid "$agent_id" --arg leader "$new_leader" \
+                '.teams[$tid].agents |= map(select(. != $aid)) | .teams[$tid].leader_agent = $leader' \
+                "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+
+            removed_from_teams+=("$team_id")
+            if [ "$current_leader" != "$new_leader" ]; then
+                reassigned_leaders+=("${team_id}:${new_leader}")
+            fi
+        done
+    fi
+
+    # Update AGENTS.md for teammates affected by membership changes.
+    if [ ${#member_teams[@]} -gt 0 ]; then
+        local affected_agent_ids
+        affected_agent_ids=$(jq -r --arg aid "$agent_id" \
+            '(.teams // {}) | to_entries[] | select(.value.agents | index($aid)) | .value.agents[]' \
+            "$SETTINGS_FILE" 2>/dev/null)
+        # Include remaining current members from previously impacted teams.
+        local team_id
+        for team_id in "${member_teams[@]}"; do
+            while IFS= read -r member_id; do
+                affected_agent_ids+=$'\n'"$member_id"
+            done < <(jq -r --arg tid "$team_id" '((.teams // {})[$tid].agents // [])[]' "$SETTINGS_FILE" 2>/dev/null)
+        done
+        while IFS= read -r affected_id; do
+            [ -z "$affected_id" ] && continue
+            [ "$affected_id" = "$agent_id" ] && continue
+            update_agent_team_info "$affected_id"
+        done < <(printf '%s\n' "$affected_agent_ids" | awk 'NF' | sort -u)
+    fi
+
     # Clean up agent state directory
     if [ -d "$AGENTS_DIR/$agent_id" ]; then
         rm -rf "$AGENTS_DIR/$agent_id"
     fi
 
     echo -e "${GREEN}✓ Agent '${agent_id}' removed.${NC}"
+    if [ ${#removed_from_teams[@]} -gt 0 ]; then
+        echo "  Removed from teams: ${removed_from_teams[*]}"
+    fi
+    if [ ${#reassigned_leaders[@]} -gt 0 ]; then
+        echo "  Reassigned leaders:"
+        local entry
+        for entry in "${reassigned_leaders[@]}"; do
+            local tid="${entry%%:*}"
+            local lid="${entry##*:}"
+            echo "    @${tid} -> @${lid}"
+        done
+    fi
+    if [ ${#removed_empty_teams[@]} -gt 0 ]; then
+        echo "  Removed empty teams: ${removed_empty_teams[*]}"
+    fi
 }
 
 # Set provider and/or model for a specific agent

--- a/lib/teams.sh
+++ b/lib/teams.sh
@@ -265,6 +265,180 @@ team_remove() {
     echo -e "${GREEN}Team '${team_id}' removed.${NC}"
 }
 
+# Add an existing agent to an existing team
+team_add_agent() {
+    local team_id="$1"
+    local agent_id="$2"
+
+    if [ -z "$team_id" ] || [ -z "$agent_id" ]; then
+        echo "Usage: $0 team add-agent <team_id> <agent_id>"
+        exit 1
+    fi
+
+    team_id=$(echo "$team_id" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')
+    agent_id=$(echo "$agent_id" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')
+
+    if [ ! -f "$SETTINGS_FILE" ]; then
+        echo -e "${RED}No settings file found.${NC}"
+        exit 1
+    fi
+
+    local team_json
+    team_json=$(jq -r "(.teams // {}).\"${team_id}\" // empty" "$SETTINGS_FILE" 2>/dev/null)
+    if [ -z "$team_json" ]; then
+        echo -e "${RED}Team '${team_id}' not found.${NC}"
+        exit 1
+    fi
+
+    local agent_json
+    agent_json=$(jq -r "(.agents // {}).\"${agent_id}\" // empty" "$SETTINGS_FILE" 2>/dev/null)
+    if [ -z "$agent_json" ]; then
+        echo -e "${RED}Agent '${agent_id}' not found.${NC}"
+        exit 1
+    fi
+
+    local already_member
+    already_member=$(jq -r --arg tid "$team_id" --arg aid "$agent_id" \
+        'if ((.teams // {})[$tid].agents | index($aid)) then "yes" else "no" end' \
+        "$SETTINGS_FILE" 2>/dev/null)
+    if [ "$already_member" = "yes" ]; then
+        echo -e "${YELLOW}Agent '${agent_id}' is already in team '${team_id}'.${NC}"
+        return
+    fi
+
+    local tmp_file="$SETTINGS_FILE.tmp"
+    jq --arg tid "$team_id" --arg aid "$agent_id" \
+        '.teams[$tid].agents += [$aid]' \
+        "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+
+    local team_name
+    team_name=$(jq -r "(.teams // {}).\"${team_id}\".name // \"${team_id}\"" "$SETTINGS_FILE" 2>/dev/null)
+
+    # Update AGENTS.md for all members in this team.
+    while IFS= read -r aid; do
+        update_agent_team_info "$aid"
+    done < <(jq -r "(.teams // {}).\"${team_id}\".agents[]" "$SETTINGS_FILE" 2>/dev/null)
+
+    echo -e "${GREEN}Added @${agent_id} to team '${team_id}' (${team_name}).${NC}"
+}
+
+# Remove an agent from an existing team
+team_remove_agent() {
+    local team_id="$1"
+    local agent_id="$2"
+
+    if [ -z "$team_id" ] || [ -z "$agent_id" ]; then
+        echo "Usage: $0 team remove-agent <team_id> <agent_id>"
+        exit 1
+    fi
+
+    team_id=$(echo "$team_id" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')
+    agent_id=$(echo "$agent_id" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')
+
+    if [ ! -f "$SETTINGS_FILE" ]; then
+        echo -e "${RED}No settings file found.${NC}"
+        exit 1
+    fi
+
+    local team_json
+    team_json=$(jq -r "(.teams // {}).\"${team_id}\" // empty" "$SETTINGS_FILE" 2>/dev/null)
+    if [ -z "$team_json" ]; then
+        echo -e "${RED}Team '${team_id}' not found.${NC}"
+        exit 1
+    fi
+
+    local is_member
+    is_member=$(jq -r --arg tid "$team_id" --arg aid "$agent_id" \
+        'if ((.teams // {})[$tid].agents | index($aid)) then "yes" else "no" end' \
+        "$SETTINGS_FILE" 2>/dev/null)
+    if [ "$is_member" != "yes" ]; then
+        echo -e "${YELLOW}Agent '${agent_id}' is not in team '${team_id}'.${NC}"
+        return
+    fi
+
+    local remaining_count
+    remaining_count=$(jq -r --arg tid "$team_id" --arg aid "$agent_id" \
+        '((.teams // {})[$tid].agents | map(select(. != $aid)) | length)' \
+        "$SETTINGS_FILE" 2>/dev/null)
+
+    if [ "$remaining_count" -lt 1 ]; then
+        echo -e "${RED}Cannot remove the last agent from team '${team_id}'.${NC}"
+        echo "Use '$0 team remove ${team_id}' to remove the whole team."
+        exit 1
+    fi
+
+    local current_leader
+    current_leader=$(jq -r "(.teams // {}).\"${team_id}\".leader_agent // empty" "$SETTINGS_FILE" 2>/dev/null)
+    local new_leader="$current_leader"
+
+    if [ "$current_leader" = "$agent_id" ]; then
+        echo ""
+        echo -e "${YELLOW}@${agent_id} is currently the leader of team '${team_id}'.${NC}"
+        echo "Choose a new leader from remaining members:"
+        jq -r --arg tid "$team_id" --arg aid "$agent_id" \
+            '((.teams // {})[$tid].agents | map(select(. != $aid))[])' \
+            "$SETTINGS_FILE" 2>/dev/null | while IFS= read -r rid; do
+                rname=""
+                rname=$(jq -r "(.agents // {}).\"${rid}\".name // \"${rid}\"" "$SETTINGS_FILE" 2>/dev/null)
+                echo "  @${rid} - ${rname}"
+            done
+
+        local suggested_leader
+        suggested_leader=$(jq -r --arg tid "$team_id" --arg aid "$agent_id" \
+            '((.teams // {})[$tid].agents | map(select(. != $aid)) | .[0]) // empty' \
+            "$SETTINGS_FILE" 2>/dev/null)
+
+        read -rp "New leader [default: ${suggested_leader}]: " new_leader
+        new_leader=$(echo "$new_leader" | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+        if [ -z "$new_leader" ]; then
+            new_leader="$suggested_leader"
+        fi
+
+        local leader_valid
+        leader_valid=$(jq -r --arg tid "$team_id" --arg aid "$agent_id" --arg leader "$new_leader" \
+            'if (((.teams // {})[$tid].agents | map(select(. != $aid))) | index($leader)) then "yes" else "no" end' \
+            "$SETTINGS_FILE" 2>/dev/null)
+        if [ "$leader_valid" != "yes" ]; then
+            echo -e "${RED}Leader '${new_leader}' must be one of the remaining team members.${NC}"
+            exit 1
+        fi
+    fi
+
+    read -rp "Remove @${agent_id} from team '${team_id}'? [y/N]: " CONFIRM
+    if [[ ! "$CONFIRM" =~ ^[yY] ]]; then
+        echo "Cancelled."
+        return
+    fi
+
+    # Capture old members for AGENTS.md updates before mutating settings.
+    local old_members=()
+    while IFS= read -r aid; do
+        old_members+=("$aid")
+    done < <(jq -r "(.teams // {}).\"${team_id}\".agents[]" "$SETTINGS_FILE" 2>/dev/null)
+
+    local tmp_file="$SETTINGS_FILE.tmp"
+    jq --arg tid "$team_id" --arg aid "$agent_id" --arg leader "$new_leader" \
+        '.teams[$tid].agents |= map(select(. != $aid)) | .teams[$tid].leader_agent = $leader' \
+        "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+
+    # Update AGENTS.md for old and current members.
+    local combined_ids
+    combined_ids=$(printf '%s\n' "${old_members[@]}" | awk 'NF' | sort -u)
+    while IFS= read -r aid; do
+        [ -z "$aid" ] && continue
+        update_agent_team_info "$aid"
+    done <<< "$combined_ids"
+    while IFS= read -r aid; do
+        update_agent_team_info "$aid"
+    done < <(jq -r "(.teams // {}).\"${team_id}\".agents[]" "$SETTINGS_FILE" 2>/dev/null)
+
+    if [ "$current_leader" != "$new_leader" ]; then
+        echo -e "${GREEN}Removed @${agent_id} from team '${team_id}'. New leader: @${new_leader}.${NC}"
+    else
+        echo -e "${GREEN}Removed @${agent_id} from team '${team_id}'.${NC}"
+    fi
+}
+
 # Update an agent's AGENTS.md with team collaboration info
 # Called after team add/remove to keep agent docs in sync
 update_agent_team_info() {

--- a/tinyclaw.sh
+++ b/tinyclaw.sh
@@ -402,6 +402,20 @@ case "${1:-}" in
                 fi
                 team_show "$3"
                 ;;
+            add-agent|agent-add|member-add)
+                if [ -z "$3" ] || [ -z "$4" ]; then
+                    echo "Usage: $0 team add-agent <team_id> <agent_id>"
+                    exit 1
+                fi
+                team_add_agent "$3" "$4"
+                ;;
+            remove-agent|agent-remove|member-remove)
+                if [ -z "$3" ] || [ -z "$4" ]; then
+                    echo "Usage: $0 team remove-agent <team_id> <agent_id>"
+                    exit 1
+                fi
+                team_remove_agent "$3" "$4"
+                ;;
             visualize|viz)
                 # Build visualizer if needed
                 if [ ! -f "$SCRIPT_DIR/dist/visualizer/team-visualizer.js" ] || \
@@ -419,13 +433,15 @@ case "${1:-}" in
                 fi
                 ;;
             *)
-                echo "Usage: $0 team {list|add|remove|show|visualize}"
+                echo "Usage: $0 team {list|add|remove|show|add-agent|remove-agent|visualize}"
                 echo ""
                 echo "Team Commands:"
                 echo "  list                   List all configured teams"
                 echo "  add                    Add a new team interactively"
                 echo "  remove <id>            Remove a team"
                 echo "  show <id>              Show team configuration"
+                echo "  add-agent <tid> <aid>  Add an existing agent to a team"
+                echo "  remove-agent <tid> <aid> Remove an agent from a team"
                 echo "  visualize [team_id]    Live TUI dashboard for team collaboration"
                 echo ""
                 echo "Examples:"
@@ -433,6 +449,8 @@ case "${1:-}" in
                 echo "  $0 team add"
                 echo "  $0 team show dev"
                 echo "  $0 team remove dev"
+                echo "  $0 team add-agent dev reviewer"
+                echo "  $0 team remove-agent dev reviewer"
                 echo "  $0 team visualize"
                 echo "  $0 team visualize dev"
                 echo ""
@@ -473,7 +491,7 @@ case "${1:-}" in
         echo "  provider [name] [--model model]  Show or switch AI provider"
         echo "  model [name]             Show or switch AI model"
         echo "  agent {list|add|remove|show|reset|provider}  Manage agents"
-        echo "  team {list|add|remove|show|visualize}  Manage teams"
+        echo "  team {list|add|remove|show|add-agent|remove-agent|visualize}  Manage teams"
         echo "  pairing {pending|approved|list|approve <code>|unpair <channel> <sender_id>}  Manage sender approvals"
         echo "  update                   Update TinyClaw to latest version"
         echo "  attach                   Attach to tmux session"


### PR DESCRIPTION
## Summary

This PR adds team member management commands and fixes stale team references when removing an agent.

It introduces team add-agent and team remove-agent, and updates agent remove to detect team memberships and clean them up safely (including leader reassignment or empty-team deletion when needed).

This PR was completed with assistance from gpt-5.3-codex.

## Changes

- Added new team CLI commands:
- tinyclaw team add-agent <team_id> <agent_id>
- tinyclaw team remove-agent <team_id> <agent_id>
- Added leader-safe removal flow for team remove-agent:
- prompts for a new leader if the removed member is current leader
- prevents removing the last team member via remove-agent (requires team remove for full deletion)
- Enhanced agent remove <agent_id>:
- checks whether the agent belongs to any teams
- prompts user that team membership will be removed together
- removes the agent from all related teams after confirmation
- auto-reassigns team leader when needed
- removes team if it becomes empty
- Updated help/usage text in CLI for new team commands
- Updated documentation:
- README.md
- docs/TEAMS.md
- docs/AGENTS.md

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement to existing feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / code cleanup

## Testing

- Ran shell syntax checks:
- bash -n lib/teams.sh
- bash -n lib/agents.sh
- bash -n tinyclaw.sh
- Ran local behavior tests using temporary TINYCLAW_HOME + test settings.json:
- team add-agent successfully adds member
- team remove-agent handles leader removal and leader reassignment
- agent remove warns about team impact and removes team membership together
- team is deleted automatically when it becomes empty

## Checklist

- [x] I have tested these changes locally
- [x] My changes don't introduce new warnings or errors
- [x] I have updated documentation if needed