### PR TITLE
fix: resolve issue #19 security gaps and logging discrepancies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyclaw",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyclaw",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "tsc && tsc -p tsconfig.visualizer.json && echo '{\"type\":\"module\"}' > dist/visualizer/package.json",
     "build:main": "tsc",
     "build:visualizer": "tsc -p tsconfig.visualizer.json && echo '{\"type\":\"module\"}' > dist/visualizer/package.json",
+    "test": "npm run build:main && node --test dist/test/**/*.test.js",
     "whatsapp": "node dist/channels/whatsapp-client.js",
     "discord": "node dist/channels/discord-client.js",
     "telegram": "node dist/channels/telegram-client.js",

--- a/src/channels/discord-client.ts
+++ b/src/channels/discord-client.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import https from 'https';
 import http from 'http';
 import { ensureSenderPaired } from '../lib/pairing';
+import { messageSizeSummary } from '../lib/privacy';
 
 const API_PORT = parseInt(process.env.TINYCLAW_API_PORT || '3777', 10);
 const API_BASE = `http://localhost:${API_PORT}`;
@@ -259,7 +260,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
 
         let messageText = message.content || '';
 
-        log('INFO', `Message from ${sender}: ${messageText.substring(0, 50)}${downloadedFiles.length > 0 ? ` [+${downloadedFiles.length} file(s)]` : ''}...`);
+        log('INFO', `Message from ${sender}: ${messageSizeSummary(messageText)}${downloadedFiles.length > 0 ? ` [+${downloadedFiles.length} file(s)]` : ''}`);
 
         const pairing = ensureSenderPaired(PAIRING_FILE, 'discord', message.author.id, sender);
         if (!pairing.approved && pairing.code) {

--- a/src/channels/telegram-client.ts
+++ b/src/channels/telegram-client.ts
@@ -14,6 +14,7 @@ import path from 'path';
 import https from 'https';
 import http from 'http';
 import { ensureSenderPaired } from '../lib/pairing';
+import { messageSizeSummary } from '../lib/privacy';
 
 const API_PORT = parseInt(process.env.TINYCLAW_API_PORT || '3777', 10);
 const API_BASE = `http://localhost:${API_PORT}`;
@@ -354,7 +355,7 @@ bot.on('message', async (msg: TelegramBot.Message) => {
             : 'Unknown';
         const senderId = msg.chat.id.toString();
 
-        log('INFO', `Message from ${sender}: ${messageText.substring(0, 50)}${downloadedFiles.length > 0 ? ` [+${downloadedFiles.length} file(s)]` : ''}...`);
+        log('INFO', `Message from ${sender}: ${messageSizeSummary(messageText)}${downloadedFiles.length > 0 ? ` [+${downloadedFiles.length} file(s)]` : ''}`);
 
         const pairing = ensureSenderPaired(PAIRING_FILE, 'telegram', senderId, sender);
         if (!pairing.approved && pairing.code) {

--- a/src/channels/whatsapp-client.ts
+++ b/src/channels/whatsapp-client.ts
@@ -10,6 +10,8 @@ import qrcode from 'qrcode-terminal';
 import fs from 'fs';
 import path from 'path';
 import { ensureSenderPaired } from '../lib/pairing';
+import { messageSizeSummary } from '../lib/privacy';
+import { buildWhatsAppChromiumArgs } from '../lib/whatsapp-launch';
 
 const API_PORT = parseInt(process.env.TINYCLAW_API_PORT || '3777', 10);
 const API_BASE = `http://localhost:${API_PORT}`;
@@ -153,6 +155,11 @@ function pairingMessage(code: string): string {
     ].join('\n');
 }
 
+const disableSandbox = process.env.WHATSAPP_DISABLE_SANDBOX === 'true';
+if (disableSandbox) {
+    log('WARN', 'WhatsApp Chromium sandbox is disabled (WHATSAPP_DISABLE_SANDBOX=true). Use only in strongly isolated environments.');
+}
+
 // Initialize WhatsApp client
 const client = new Client({
     authStrategy: new LocalAuth({
@@ -160,15 +167,7 @@ const client = new Client({
     }),
     puppeteer: {
         headless: 'new' as any,
-        args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-dev-shm-usage',
-            '--disable-accelerated-2d-canvas',
-            '--no-first-run',
-            '--no-zygote',
-            '--disable-gpu'
-        ]
+        args: buildWhatsAppChromiumArgs(disableSandbox)
     }
 });
 
@@ -259,7 +258,7 @@ client.on('message_create', async (message: Message) => {
             return;
         }
 
-        log('INFO', `📱 Message from ${sender}: ${messageText.substring(0, 50)}${downloadedFiles.length > 0 ? ` [+${downloadedFiles.length} file(s)]` : ''}...`);
+        log('INFO', `📱 Message from ${sender}: ${messageSizeSummary(messageText)}${downloadedFiles.length > 0 ? ` [+${downloadedFiles.length} file(s)]` : ''}`);
 
         const pairing = ensureSenderPaired(PAIRING_FILE, 'whatsapp', message.from, sender);
         if (!pairing.approved && pairing.code) {

--- a/src/lib/privacy.ts
+++ b/src/lib/privacy.ts
@@ -1,0 +1,10 @@
+export function messageSizeSummary(text: string): string {
+    const length = (text || '').length;
+    if (length === 0) {
+        return 'empty message';
+    }
+    if (length === 1) {
+        return '1 character';
+    }
+    return `${length} characters`;
+}

--- a/src/lib/whatsapp-launch.ts
+++ b/src/lib/whatsapp-launch.ts
@@ -1,0 +1,15 @@
+export function buildWhatsAppChromiumArgs(disableSandbox: boolean): string[] {
+    const baseArgs = [
+        '--disable-dev-shm-usage',
+        '--disable-accelerated-2d-canvas',
+        '--no-first-run',
+        '--no-zygote',
+        '--disable-gpu',
+    ];
+
+    if (!disableSandbox) {
+        return baseArgs;
+    }
+
+    return ['--no-sandbox', '--disable-setuid-sandbox', ...baseArgs];
+}

--- a/src/queue-processor.ts
+++ b/src/queue-processor.ts
@@ -22,6 +22,7 @@ import {
     getSettings, getAgents, getTeams
 } from './lib/config';
 import { log, emitEvent } from './lib/logging';
+import { messageSizeSummary } from './lib/privacy';
 import { parseAgentRouting, findTeamForAgent, getAgentResetFlag, extractTeammateMentions } from './lib/routing';
 import { invokeAgent } from './lib/invoke';
 import { loadPlugins, runIncomingHooks, runOutgoingHooks } from './lib/plugins';
@@ -68,7 +69,7 @@ async function processMessage(dbMsg: DbMessage): Promise<void> {
             fromAgent: dbMsg.from_agent ?? undefined,
         };
 
-        log('INFO', `Processing [${isInternal ? 'internal' : channel}] ${isInternal ? `@${dbMsg.from_agent}→@${dbMsg.agent}` : `from ${sender}`}: ${rawMessage.substring(0, 50)}...`);
+        log('INFO', `Processing [${isInternal ? 'internal' : channel}] ${isInternal ? `@${dbMsg.from_agent}→@${dbMsg.agent}` : `from ${sender}`}: ${messageSizeSummary(rawMessage)}`);
         if (!isInternal) {
             emitEvent('message_received', { channel, sender, message: rawMessage.substring(0, 120), messageId });
         }

--- a/src/test/privacy.test.ts
+++ b/src/test/privacy.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { messageSizeSummary } from '../lib/privacy';
+
+test('messageSizeSummary reports empty message', () => {
+    assert.equal(messageSizeSummary(''), 'empty message');
+});
+
+test('messageSizeSummary reports singular/plural sizes', () => {
+    assert.equal(messageSizeSummary('a'), '1 character');
+    assert.equal(messageSizeSummary('abcd'), '4 characters');
+});

--- a/src/test/whatsapp-launch.test.ts
+++ b/src/test/whatsapp-launch.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildWhatsAppChromiumArgs } from '../lib/whatsapp-launch';
+
+test('buildWhatsAppChromiumArgs keeps sandbox enabled by default', () => {
+    const args = buildWhatsAppChromiumArgs(false);
+    assert.equal(args.includes('--no-sandbox'), false);
+    assert.equal(args.includes('--disable-setuid-sandbox'), false);
+    assert.equal(args.includes('--disable-dev-shm-usage'), true);
+});
+
+test('buildWhatsAppChromiumArgs can disable sandbox explicitly', () => {
+    const args = buildWhatsAppChromiumArgs(true);
+    assert.equal(args[0], '--no-sandbox');
+    assert.equal(args[1], '--disable-setuid-sandbox');
+});


### PR DESCRIPTION
## Summary
Fixes key security and discrepancy items in #19:

- remove plaintext message content snippets from logs (queue processor + channel clients)
- keep Chromium sandbox enabled by default for WhatsApp
- allow sandbox disable only via explicit opt-in env (`WHATSAPP_DISABLE_SANDBOX=true`) with warning log
- add tests for both privacy-safe logging helper and WhatsApp launch args behavior

## Details
### 1) Sensitive message logging
Previous code logged `message.substring(0, 50)` from user content in multiple places.
This change introduces `messageSizeSummary()` and logs only message length metadata, e.g. `42 characters`, avoiding plaintext snippets at rest in log files.

Touched files:
- `src/queue-processor.ts`
- `src/channels/discord-client.ts`
- `src/channels/telegram-client.ts`
- `src/channels/whatsapp-client.ts`
- `src/lib/privacy.ts` (new)

### 2) WhatsApp Chromium sandbox
Previous launch args always disabled sandbox (`--no-sandbox`, `--disable-setuid-sandbox`).
Now sandbox remains enabled by default. Sandbox disable is opt-in via `WHATSAPP_DISABLE_SANDBOX=true` for environments that require it.

Touched files:
- `src/channels/whatsapp-client.ts`
- `src/lib/whatsapp-launch.ts` (new)

### 3) Tests
Added Node built-in test coverage:
- `src/test/privacy.test.ts`
- `src/test/whatsapp-launch.test.ts`
- `package.json` test script: `npm run build:main && node --test dist/test/**/*.test.js`

## Validation
- `npm run build:main` ✅
- `npm run test` ✅ (4 tests passing)

## Notes
Issue #19 also discusses command injection and allowlist concerns.
On current `main`, invocation already uses `spawn(command, args)` (no shell interpolation), and pairing-based sender gating is present in all channel clients. This PR focuses on the remaining concrete security/privacy deltas from that report (message-at-rest leakage and sandbox defaults).
