### PR TITLE
feat: add Cursor CLI as AI provider

### DIFF
--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -150,10 +150,12 @@ agent_add() {
     echo "  1) Anthropic (Claude)"
     echo "  2) OpenAI (Codex)"
     echo "  3) OpenCode"
-    read -rp "Choose [1-3, default: 1]: " AGENT_PROVIDER_CHOICE
+    echo "  4) Cursor"
+    read -rp "Choose [1-4, default: 1]: " AGENT_PROVIDER_CHOICE
     case "$AGENT_PROVIDER_CHOICE" in
         2) AGENT_PROVIDER="openai" ;;
         3) AGENT_PROVIDER="opencode" ;;
+        4) AGENT_PROVIDER="cursor" ;;
         *) AGENT_PROVIDER="anthropic" ;;
     esac
 
@@ -190,6 +192,21 @@ agent_add() {
             7) AGENT_MODEL="openai/gpt-5.3-codex" ;;
             8) read -rp "Enter model name (e.g. provider/model): " AGENT_MODEL ;;
             *) AGENT_MODEL="opencode/claude-sonnet-4-5" ;;
+        esac
+    elif [ "$AGENT_PROVIDER" = "cursor" ]; then
+        echo "Model:"
+        echo "  1) Auto (let Cursor choose)"
+        echo "  2) Sonnet (claude-sonnet-4-5)"
+        echo "  3) Opus (claude-opus-4-6)"
+        echo "  4) GPT-5.2"
+        echo "  5) Custom (enter model name)"
+        read -rp "Choose [1-5, default: 1]: " AGENT_MODEL_CHOICE
+        case "$AGENT_MODEL_CHOICE" in
+            2) AGENT_MODEL="sonnet" ;;
+            3) AGENT_MODEL="opus" ;;
+            4) AGENT_MODEL="gpt-5.2" ;;
+            5) read -rp "Enter model name: " AGENT_MODEL ;;
+            *) AGENT_MODEL="auto" ;;
         esac
     else
         echo "Model:"
@@ -517,15 +534,32 @@ agent_provider() {
                 echo "Use 'tinyclaw agent provider ${agent_id} openai --model {gpt-5.3-codex|gpt-5.2}' to also set the model."
             fi
             ;;
+        cursor)
+            if [ -n "$model_arg" ]; then
+                jq --arg id "$agent_id" --arg model "$model_arg" \
+                    '.agents[$id].provider = "cursor" | .agents[$id].model = $model' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to Cursor with model: ${model_arg}${NC}"
+            else
+                jq --arg id "$agent_id" \
+                    '.agents[$id].provider = "cursor"' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to Cursor${NC}"
+                echo ""
+                echo "Use 'tinyclaw agent provider ${agent_id} cursor --model {auto|sonnet|opus}' to also set the model."
+            fi
+            ;;
         *)
-            echo "Usage: tinyclaw agent provider <agent_id> {anthropic|openai} [--model MODEL_NAME]"
+            echo "Usage: tinyclaw agent provider <agent_id> {anthropic|openai|cursor} [--model MODEL_NAME]"
             echo ""
             echo "Examples:"
             echo "  tinyclaw agent provider coder                                    # Show current provider/model"
             echo "  tinyclaw agent provider coder anthropic                           # Switch to Anthropic"
             echo "  tinyclaw agent provider coder openai                              # Switch to OpenAI"
+            echo "  tinyclaw agent provider coder cursor                              # Switch to Cursor"
             echo "  tinyclaw agent provider coder anthropic --model opus              # Switch to Anthropic Opus"
             echo "  tinyclaw agent provider coder openai --model gpt-5.3-codex        # Switch to OpenAI GPT-5.3 Codex"
+            echo "  tinyclaw agent provider coder cursor --model auto                 # Switch to Cursor with auto model"
             exit 1
             ;;
     esac

--- a/lib/setup-wizard.sh
+++ b/lib/setup-wizard.sh
@@ -102,13 +102,15 @@ echo ""
 echo "  1) Anthropic (Claude)  (recommended)"
 echo "  2) OpenAI (Codex/GPT)"
 echo "  3) OpenCode"
+echo "  4) Cursor"
 echo ""
-read -rp "Choose [1-3]: " PROVIDER_CHOICE
+read -rp "Choose [1-4]: " PROVIDER_CHOICE
 
 case "$PROVIDER_CHOICE" in
     1) PROVIDER="anthropic" ;;
     2) PROVIDER="openai" ;;
     3) PROVIDER="opencode" ;;
+    4) PROVIDER="cursor" ;;
     *)
         echo -e "${RED}Invalid choice${NC}"
         exit 1
@@ -173,6 +175,36 @@ elif [ "$PROVIDER" = "opencode" ]; then
             fi
             ;;
         *) MODEL="opencode/claude-sonnet-4-5" ;;
+    esac
+    echo -e "${GREEN}✓ Model: $MODEL${NC}"
+    echo ""
+elif [ "$PROVIDER" = "cursor" ]; then
+    echo "Which Cursor model?"
+    echo ""
+    echo "  1) Auto  (let Cursor choose, recommended)"
+    echo "  2) Sonnet (claude-sonnet-4-5)"
+    echo "  3) Opus   (claude-opus-4-6)"
+    echo "  4) GPT-5.2"
+    echo "  5) Custom  (enter model name)"
+    echo ""
+    read -rp "Choose [1-5]: " MODEL_CHOICE
+
+    case "$MODEL_CHOICE" in
+        1) MODEL="auto" ;;
+        2) MODEL="sonnet" ;;
+        3) MODEL="opus" ;;
+        4) MODEL="gpt-5.2" ;;
+        5)
+            read -rp "Enter model name: " MODEL
+            if [ -z "$MODEL" ]; then
+                echo -e "${RED}Model name required${NC}"
+                exit 1
+            fi
+            ;;
+        *)
+            echo -e "${RED}Invalid choice${NC}"
+            exit 1
+            ;;
     esac
     echo -e "${GREEN}✓ Model: $MODEL${NC}"
     echo ""
@@ -288,11 +320,12 @@ if [[ "$SETUP_AGENTS" =~ ^[yY] ]]; then
         read -rp "  Display name: " NEW_AGENT_NAME
         [ -z "$NEW_AGENT_NAME" ] && NEW_AGENT_NAME="$NEW_AGENT_ID"
 
-        echo "  Provider: 1) Anthropic  2) OpenAI  3) OpenCode"
-        read -rp "  Choose [1-3, default: 1]: " NEW_PROVIDER_CHOICE
+        echo "  Provider: 1) Anthropic  2) OpenAI  3) OpenCode  4) Cursor"
+        read -rp "  Choose [1-4, default: 1]: " NEW_PROVIDER_CHOICE
         case "$NEW_PROVIDER_CHOICE" in
             2) NEW_PROVIDER="openai" ;;
             3) NEW_PROVIDER="opencode" ;;
+            4) NEW_PROVIDER="cursor" ;;
             *) NEW_PROVIDER="anthropic" ;;
         esac
 
@@ -313,6 +346,16 @@ if [[ "$SETUP_AGENTS" =~ ^[yY] ]]; then
                 4) NEW_MODEL="anthropic/claude-sonnet-4-5" ;;
                 5) read -rp "  Enter model name (e.g. provider/model): " NEW_MODEL ;;
                 *) NEW_MODEL="opencode/claude-sonnet-4-5" ;;
+            esac
+        elif [ "$NEW_PROVIDER" = "cursor" ]; then
+            echo "  Model: 1) Auto  2) Sonnet  3) Opus  4) GPT-5.2  5) Custom"
+            read -rp "  Choose [1-5, default: 1]: " NEW_MODEL_CHOICE
+            case "$NEW_MODEL_CHOICE" in
+                2) NEW_MODEL="sonnet" ;;
+                3) NEW_MODEL="opus" ;;
+                4) NEW_MODEL="gpt-5.2" ;;
+                5) read -rp "  Enter model name: " NEW_MODEL ;;
+                *) NEW_MODEL="auto" ;;
             esac
         else
             echo "  Model: 1) GPT-5.3 Codex  2) GPT-5.2  3) Custom"
@@ -357,6 +400,8 @@ if [ "$PROVIDER" = "anthropic" ]; then
     MODELS_SECTION='"models": { "provider": "anthropic", "anthropic": { "model": "'"${MODEL}"'" } }'
 elif [ "$PROVIDER" = "opencode" ]; then
     MODELS_SECTION='"models": { "provider": "opencode", "opencode": { "model": "'"${MODEL}"'" } }'
+elif [ "$PROVIDER" = "cursor" ]; then
+    MODELS_SECTION='"models": { "provider": "cursor", "cursor": { "model": "'"${MODEL}"'" } }'
 else
     MODELS_SECTION='"models": { "provider": "openai", "openai": { "model": "'"${MODEL}"'" } }'
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyclaw",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyclaw",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "@types/better-sqlite3": "^7.6.13",

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -73,6 +73,13 @@ export function ensureAgentDirectory(agentDir: string): void {
         copyDirSync(targetAgentsSkills, targetClaudeSkills);
     }
 
+    // Copy AGENTS.md as .cursor/rules/agents.mdc for Cursor CLI
+    if (fs.existsSync(sourceAgents)) {
+        const targetCursorRules = path.join(agentDir, '.cursor', 'rules');
+        fs.mkdirSync(targetCursorRules, { recursive: true });
+        fs.copyFileSync(sourceAgents, path.join(targetCursorRules, 'agents.mdc'));
+    }
+
     // Create .tinyclaw directory and copy SOUL.md
     const targetTinyclaw = path.join(agentDir, '.tinyclaw');
     fs.mkdirSync(targetTinyclaw, { recursive: true });
@@ -144,4 +151,19 @@ export function updateAgentTeammates(agentDir: string, agentId: string, agents: 
         claudeContent = claudeContent.trimEnd() + '\n\n' + startMarker + block + endMarker + '\n';
     }
     fs.writeFileSync(claudeMdPath, claudeContent);
+
+    // Also write to .cursor/rules/agents.mdc for Cursor CLI
+    const cursorRulesDir = path.join(agentDir, '.cursor', 'rules');
+    const cursorRulePath = path.join(cursorRulesDir, 'agents.mdc');
+    if (fs.existsSync(cursorRulePath)) {
+        let cursorContent = fs.readFileSync(cursorRulePath, 'utf8');
+        const crStartIdx = cursorContent.indexOf(startMarker);
+        const crEndIdx = cursorContent.indexOf(endMarker);
+        if (crStartIdx !== -1 && crEndIdx !== -1) {
+            cursorContent = cursorContent.substring(0, crStartIdx + startMarker.length) + block + cursorContent.substring(crEndIdx);
+        } else {
+            cursorContent = cursorContent.trimEnd() + '\n\n' + startMarker + block + endMarker + '\n';
+        }
+        fs.writeFileSync(cursorRulePath, cursorContent);
+    }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { jsonrepair } from 'jsonrepair';
-import { Settings, AgentConfig, TeamConfig, CLAUDE_MODEL_IDS, CODEX_MODEL_IDS, OPENCODE_MODEL_IDS } from './types';
+import { Settings, AgentConfig, TeamConfig, CLAUDE_MODEL_IDS, CODEX_MODEL_IDS, OPENCODE_MODEL_IDS, CURSOR_MODEL_IDS } from './types';
 
 export const SCRIPT_DIR = path.resolve(__dirname, '../..');
 const _localTinyclaw = path.join(SCRIPT_DIR, '.tinyclaw');
@@ -45,6 +45,9 @@ export function getSettings(): Settings {
             if (settings?.models?.openai) {
                 if (!settings.models) settings.models = {};
                 settings.models.provider = 'openai';
+            } else if (settings?.models?.cursor) {
+                if (!settings.models) settings.models = {};
+                settings.models.provider = 'cursor';
             } else if (settings?.models?.opencode) {
                 if (!settings.models) settings.models = {};
                 settings.models.provider = 'opencode';
@@ -71,6 +74,8 @@ export function getDefaultAgentFromModels(settings: Settings): AgentConfig {
         model = settings?.models?.openai?.model || 'gpt-5.3-codex';
     } else if (provider === 'opencode') {
         model = settings?.models?.opencode?.model || 'sonnet';
+    } else if (provider === 'cursor') {
+        model = settings?.models?.cursor?.model || 'auto';
     } else {
         model = settings?.models?.anthropic?.model || 'sonnet';
     }
@@ -126,4 +131,12 @@ export function resolveCodexModel(model: string): string {
  */
 export function resolveOpenCodeModel(model: string): string {
     return OPENCODE_MODEL_IDS[model] || model || '';
+}
+
+/**
+ * Resolve the model ID for Cursor CLI (passed via --model flag).
+ * Falls back to the raw model string from settings if no mapping is found.
+ */
+export function resolveCursorModel(model: string): string {
+    return CURSOR_MODEL_IDS[model] || model || '';
 }

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { AgentConfig, TeamConfig } from './types';
-import { SCRIPT_DIR, resolveClaudeModel, resolveCodexModel, resolveOpenCodeModel } from './config';
+import { SCRIPT_DIR, resolveClaudeModel, resolveCodexModel, resolveOpenCodeModel, resolveCursorModel } from './config';
 import { log } from './logging';
 import { ensureAgentDirectory, updateAgentTeammates } from './agent';
 
@@ -156,6 +156,59 @@ export async function invokeAgent(
         }
 
         return response || 'Sorry, I could not generate a response from OpenCode.';
+    } else if (provider === 'cursor') {
+        // Cursor CLI — non-interactive mode via `agent -p`.
+        // Uses --output-format json for structured output; single JSON object with .result field.
+        // Supports --continue for session continuation and --force for auto-approving tool calls.
+        const modelId = resolveCursorModel(agent.model);
+        log('INFO', `Using Cursor CLI (agent: ${agentId}, model: ${modelId || 'auto'})`);
+
+        const continueConversation = !shouldReset;
+
+        if (shouldReset) {
+            log('INFO', `🔄 Resetting Cursor conversation for agent: ${agentId}`);
+        }
+
+        const buildCursorArgs = (withContinue: boolean) => {
+            const args = ['-p', message, '--output-format', 'json', '--force'];
+            if (modelId) {
+                args.push('--model', modelId);
+            }
+            if (withContinue) {
+                args.push('--continue');
+            }
+            args.push('--workspace', workingDir);
+            return args;
+        };
+
+        const parseCursorOutput = (output: string): string | null => {
+            try {
+                const json = JSON.parse(output.trim());
+                if (json.type === 'result' && json.subtype === 'success' && json.result) {
+                    return json.result;
+                }
+            } catch (e) {
+                if (output.trim()) {
+                    return output.trim();
+                }
+            }
+            return null;
+        };
+
+        let cursorOutput: string;
+        try {
+            cursorOutput = await runCommand('agent', buildCursorArgs(continueConversation), workingDir);
+        } catch (err: any) {
+            // --continue fails when no previous session exists; retry without it
+            if (continueConversation && err?.message?.includes('No previous chats found')) {
+                log('INFO', `No previous Cursor session for agent ${agentId}, starting fresh`);
+                cursorOutput = await runCommand('agent', buildCursorArgs(false), workingDir);
+            } else {
+                throw err;
+            }
+        }
+
+        return parseCursorOutput(cursorOutput) || 'Sorry, I could not generate a response from Cursor.';
     } else {
         // Default to Claude (Anthropic)
         log('INFO', `Using Claude provider (agent: ${agentId})`);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 export interface AgentConfig {
     name: string;
-    provider: string;       // 'anthropic', 'openai', or 'opencode'
+    provider: string;       // 'anthropic', 'openai', 'opencode', or 'cursor'
     model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex'
     working_directory: string;
     system_prompt?: string;
@@ -43,7 +43,7 @@ export interface Settings {
         whatsapp?: {};
     };
     models?: {
-        provider?: string; // 'anthropic', 'openai', or 'opencode'
+        provider?: string; // 'anthropic', 'openai', 'opencode', or 'cursor'
         anthropic?: {
             model?: string;
         };
@@ -51,6 +51,9 @@ export interface Settings {
             model?: string;
         };
         opencode?: {
+            model?: string;
+        };
+        cursor?: {
             model?: string;
         };
     };
@@ -139,4 +142,15 @@ export const OPENCODE_MODEL_IDS: Record<string, string> = {
     // Shorthand aliases
     'sonnet': 'opencode/claude-sonnet-4-5',
     'opus': 'opencode/claude-opus-4-6',
+};
+
+// Cursor CLI model IDs. Available models depend on the user's subscription;
+// run `agent models` to list them. Falls back to the raw model string.
+export const CURSOR_MODEL_IDS: Record<string, string> = {
+    'sonnet': 'claude-sonnet-4-5',
+    'opus': 'claude-opus-4-6',
+    'claude-sonnet-4-5': 'claude-sonnet-4-5',
+    'claude-opus-4-6': 'claude-opus-4-6',
+    'gpt-5.2': 'gpt-5.2',
+    'auto': 'auto',
 };

--- a/tinyclaw.sh
+++ b/tinyclaw.sh
@@ -96,6 +96,10 @@ case "${1:-}" in
                 CURRENT_PROVIDER=$(jq -r '.models.provider // "anthropic"' "$SETTINGS_FILE" 2>/dev/null)
                 if [ "$CURRENT_PROVIDER" = "openai" ]; then
                     CURRENT_MODEL=$(jq -r '.models.openai.model // empty' "$SETTINGS_FILE" 2>/dev/null)
+                elif [ "$CURRENT_PROVIDER" = "cursor" ]; then
+                    CURRENT_MODEL=$(jq -r '.models.cursor.model // empty' "$SETTINGS_FILE" 2>/dev/null)
+                elif [ "$CURRENT_PROVIDER" = "opencode" ]; then
+                    CURRENT_MODEL=$(jq -r '.models.opencode.model // empty' "$SETTINGS_FILE" 2>/dev/null)
                 else
                     CURRENT_MODEL=$(jq -r '.models.anthropic.model // empty' "$SETTINGS_FILE" 2>/dev/null)
                 fi
@@ -197,16 +201,49 @@ case "${1:-}" in
                         echo "Note: Make sure you have the 'codex' CLI installed and authenticated."
                     fi
                     ;;
+                cursor)
+                    if [ ! -f "$SETTINGS_FILE" ]; then
+                        echo -e "${RED}No settings file found. Run setup first.${NC}"
+                        exit 1
+                    fi
+
+                    # Switch to Cursor provider (using Cursor CLI `agent`)
+                    tmp_file="$SETTINGS_FILE.tmp"
+                    if [ -n "$MODEL_ARG" ]; then
+                        UPDATED_COUNT=$(jq --arg old_provider "$OLD_PROVIDER" '[.agents // {} | to_entries[] | select(.value.provider == $old_provider)] | length' "$SETTINGS_FILE" 2>/dev/null)
+                        jq --arg model "$MODEL_ARG" --arg old_provider "$OLD_PROVIDER" '
+                            .models.provider = "cursor" |
+                            .models.cursor.model = $model |
+                            .agents //= {} |
+                            .agents |= with_entries(
+                                if .value.provider == $old_provider then .value.provider = "cursor" | .value.model = $model else . end
+                            )
+                        ' "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                        echo -e "${GREEN}✓ Switched to Cursor provider with model: $MODEL_ARG${NC}"
+                        if [ "$UPDATED_COUNT" -gt 0 ] 2>/dev/null; then
+                            echo -e "${BLUE}  Updated $UPDATED_COUNT agent(s) from $OLD_PROVIDER to cursor/$MODEL_ARG${NC}"
+                        fi
+                        echo ""
+                        echo "Note: Make sure you have the 'agent' CLI installed (curl https://cursor.com/install -fsS | bash) and authenticated (agent login)."
+                    else
+                        jq '.models.provider = "cursor"' "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                        echo -e "${GREEN}✓ Switched to Cursor provider${NC}"
+                        echo ""
+                        echo "Use 'tinyclaw model {sonnet|opus|auto}' to set the model."
+                        echo "Note: Make sure you have the 'agent' CLI installed (curl https://cursor.com/install -fsS | bash) and authenticated (agent login)."
+                    fi
+                    ;;
                 *)
-                    echo "Usage: $0 provider {anthropic|openai} [--model MODEL_NAME]"
+                    echo "Usage: $0 provider {anthropic|openai|cursor} [--model MODEL_NAME]"
                     echo ""
                     echo "Examples:"
                     echo "  $0 provider                                    # Show current provider and model"
                     echo "  $0 provider anthropic                          # Switch to Anthropic"
                     echo "  $0 provider openai                             # Switch to OpenAI"
+                    echo "  $0 provider cursor                             # Switch to Cursor"
                     echo "  $0 provider anthropic --model sonnet           # Switch to Anthropic with Sonnet"
                     echo "  $0 provider openai --model gpt-5.3-codex       # Switch to OpenAI with GPT-5.3 Codex"
-                    echo "  $0 provider openai --model gpt-4o              # Switch to OpenAI with custom model"
+                    echo "  $0 provider cursor --model auto                # Switch to Cursor with auto model"
                     exit 1
                     ;;
             esac
@@ -218,6 +255,10 @@ case "${1:-}" in
                 CURRENT_PROVIDER=$(jq -r '.models.provider // "anthropic"' "$SETTINGS_FILE" 2>/dev/null)
                 if [ "$CURRENT_PROVIDER" = "openai" ]; then
                     CURRENT_MODEL=$(jq -r '.models.openai.model // empty' "$SETTINGS_FILE" 2>/dev/null)
+                elif [ "$CURRENT_PROVIDER" = "cursor" ]; then
+                    CURRENT_MODEL=$(jq -r '.models.cursor.model // empty' "$SETTINGS_FILE" 2>/dev/null)
+                elif [ "$CURRENT_PROVIDER" = "opencode" ]; then
+                    CURRENT_MODEL=$(jq -r '.models.opencode.model // empty' "$SETTINGS_FILE" 2>/dev/null)
                 else
                     CURRENT_MODEL=$(jq -r '.models.anthropic.model // empty' "$SETTINGS_FILE" 2>/dev/null)
                 fi


### PR DESCRIPTION
## Summary

Adds the [Cursor CLI](https://cursor.com/docs/cli/overview) (`agent`) as a fourth AI provider, alongside Anthropic (Claude), OpenAI (Codex), and OpenCode.

This lets users leverage their existing Cursor subscription within TinyClaw — useful for teams that already have Cursor Pro/Business seats and want to use them for autonomous agent workflows.

### What's included

- **TypeScript integration** (`src/lib/`):
  - `types.ts` — `CURSOR_MODEL_IDS` mapping and `cursor` settings type
  - `config.ts` — `resolveCursorModel()` resolver and auto-detect for cursor provider
  - `invoke.ts` — Full provider branch: JSON output parsing, `--continue` session support, `--force` for non-interactive mode, graceful fallback when no previous session exists
  - `agent.ts` — Copies `AGENTS.md` as `.cursor/rules/agents.mdc` so Cursor agents get the same context as Claude agents, with teammate info kept in sync

- **Shell scripts**:
  - `tinyclaw.sh` — `provider cursor` command for global switching, model display
  - `lib/agents.sh` — Cursor option in `agent add` and `agent provider` menus
  - `lib/setup-wizard.sh` — Cursor in initial setup and additional agent flows

### How it works

The Cursor CLI's non-interactive mode (`agent -p "prompt" --output-format json --force`) returns a single JSON object with a `.result` field. The integration:

1. Resolves model IDs via `CURSOR_MODEL_IDS` (supports shorthand like `sonnet`, `opus`, `auto`)
2. Builds args with `--model`, `--workspace`, and optionally `--continue`
3. Parses the JSON output, falling back to raw text if parsing fails
4. Handles the "No previous chats found" error by retrying without `--continue`

### Prerequisites

Users need the Cursor CLI installed and authenticated:
```bash
curl https://cursor.com/install -fsS | bash
agent login  # or set CURSOR_API_KEY
```

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] `tinyclaw setup` — select Cursor as provider, verify settings.json
- [ ] `tinyclaw agent add` — create a Cursor agent, verify provider/model
- [ ] `tinyclaw agent provider <id> cursor --model auto` — switch existing agent
- [ ] Send a message to a Cursor agent and verify response parsing
- [ ] Verify `.cursor/rules/agents.mdc` is created in agent workspace
- [ ] Verify `--continue` works for subsequent messages (session persistence)

Made with [Cursor](https://cursor.com)