### PR TITLE
fixes ISSUE 160 - prevents tag mismatch with package version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,21 @@ jobs:
           node-version: '18'
           cache: 'npm'
 
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED_TAG="v${PACKAGE_VERSION}"
+          ACTUAL_TAG="${GITHUB_REF#refs/tags/}"
+
+          if [ "$ACTUAL_TAG" != "$EXPECTED_TAG" ]; then
+            echo "::warning::Version mismatch detected. Bump package.json version before tagging a release."
+            echo "::error::Tag/package version mismatch. expected=${EXPECTED_TAG}, actual=${ACTUAL_TAG}"
+            exit 1
+          fi
+
+          echo "Tag and package.json version match: ${ACTUAL_TAG}"
+
       - name: Get version from tag
         id: get_version
         run: |


### PR DESCRIPTION
## Summary

Adds a guard to the release github action so that the package and the tag must be in sync

## Changes

This adds a step to the github action to perform the check and fail the PR checks if the version is not in sync.

-

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Testing

We're doing it live.

-

## Checklist

This is an action-specific change that will only work in GitHub.
