### PR TITLE
fix: bump version to 0.0.10 (fixes #164)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyclaw",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyclaw",
-      "version": "0.0.6",
+      "version": "0.0.10",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyclaw",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Multi-agent, multi-team, multi-channel 24/7 AI assistant",
   "scripts": {
     "build": "tsc && tsc -p tsconfig.visualizer.json && echo '{\"type\":\"module\"}' > dist/visualizer/package.json",


### PR DESCRIPTION
## Summary
- Bumps version from 0.0.9 to 0.0.10 in both `package.json` and `package-lock.json`
- The v0.0.9 release bundle was built from a commit where `package.json` still had version `0.0.8`, because the `v0.0.9` tag was placed on a commit *before* the version bump
- Also fixes `package-lock.json` which was stuck at `0.0.6`

## Root cause
The `v0.0.9` git tag pointed to commit `048dbea` which was before both:
1. The version bump commit (`a84c90b` - changed package.json from 0.0.8 to 0.0.9)
2. The tag verification workflow step (`2f91934` - which would have caught this)

So the release workflow built the bundle with the old version in package.json.

## What this fixes
After merging, tag `v0.0.10` on this commit and create a release. The existing tag verification step in the release workflow will prevent this issue from recurring.

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)