### PR TITLE
feat: sticky default agent per chat on channel clients

### DIFF
--- a/src/channels/default-agent.ts
+++ b/src/channels/default-agent.ts
@@ -5,89 +5,76 @@
  * as the default for the chat. Subsequent messages without an @-prefix are
  * automatically routed to the stored default agent.
  *
- * Defaults persist across restarts via a JSON file in TINYCLAW_HOME.
+ * Defaults persist in settings.json under the `channel_defaults` key.
  */
 
 import fs from 'fs';
-import path from 'path';
-
-// Per-chat default agent: chatKey → agentId (the raw @-prefix value)
-let defaultAgentPerChat = new Map<string, string>();
-let persistPath: string | null = null;
-
-/**
- * Initialize persistence. Call once at startup with the TINYCLAW_HOME path.
- * If not called, defaults are in-memory only.
- */
-export function initPersistence(tinyclawHome: string): void {
-    persistPath = path.join(tinyclawHome, 'default-agents.json');
-    try {
-        if (fs.existsSync(persistPath)) {
-            const data = JSON.parse(fs.readFileSync(persistPath, 'utf8'));
-            defaultAgentPerChat = new Map(Object.entries(data));
-        }
-    } catch {
-        // Corrupt or unreadable — start fresh
-    }
-}
-
-function saveDefaults(): void {
-    if (!persistPath) return;
-    try {
-        const dir = path.dirname(persistPath);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(persistPath, JSON.stringify(Object.fromEntries(defaultAgentPerChat)));
-    } catch {
-        // Best-effort persistence
-    }
-}
 
 interface AgentMatchResult {
-    /** The @-prefix value the user typed (e.g. "coder") */
     tag: string;
-    /** Display name resolved from settings (e.g. "Coder") */
     displayName: string;
-    /** Whether this matched a team rather than an agent */
     isTeam: boolean;
+}
+
+function readSettings(settingsFile: string): any {
+    try {
+        return JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    } catch {
+        return {};
+    }
+}
+
+function getDefaults(settingsFile: string): Record<string, string> {
+    return readSettings(settingsFile).channel_defaults || {};
+}
+
+function saveDefault(settingsFile: string, chatKey: string, agentId: string): void {
+    try {
+        const settings = readSettings(settingsFile);
+        if (!settings.channel_defaults) settings.channel_defaults = {};
+        settings.channel_defaults[chatKey] = agentId;
+        fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+    } catch {
+        // Best-effort
+    }
+}
+
+function deleteDefault(settingsFile: string, chatKey: string): void {
+    try {
+        const settings = readSettings(settingsFile);
+        if (settings.channel_defaults) {
+            delete settings.channel_defaults[chatKey];
+            fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+        }
+    } catch {
+        // Best-effort
+    }
 }
 
 /**
  * Try to resolve a candidate tag to a valid agent or team.
- * Returns match info or null if no match found.
  */
 export function resolveAgentTag(candidateTag: string, settingsFile: string): AgentMatchResult | null {
-    try {
-        const settingsData = fs.readFileSync(settingsFile, 'utf8');
-        const settings = JSON.parse(settingsData);
-        const agents = settings.agents || {};
-        const teams = settings.teams || {};
-        const candidate = candidateTag.toLowerCase();
+    const settings = readSettings(settingsFile);
+    const agents = settings.agents || {};
+    const teams = settings.teams || {};
+    const candidate = candidateTag.toLowerCase();
 
-        // Check agent IDs
-        if (agents[candidate]) {
-            return { tag: candidate, displayName: agents[candidate].name, isTeam: false };
+    if (agents[candidate]) {
+        return { tag: candidate, displayName: agents[candidate].name, isTeam: false };
+    }
+    if (teams[candidate]) {
+        return { tag: candidate, displayName: teams[candidate].name, isTeam: true };
+    }
+    for (const [id, config] of Object.entries(agents) as [string, any][]) {
+        if (config.name.toLowerCase() === candidate) {
+            return { tag: id, displayName: config.name, isTeam: false };
         }
-
-        // Check team IDs
-        if (teams[candidate]) {
-            return { tag: candidate, displayName: teams[candidate].name, isTeam: true };
+    }
+    for (const [id, config] of Object.entries(teams) as [string, any][]) {
+        if (config.name.toLowerCase() === candidate) {
+            return { tag: id, displayName: config.name, isTeam: true };
         }
-
-        // Match by agent name (case-insensitive)
-        for (const [id, config] of Object.entries(agents) as [string, any][]) {
-            if (config.name.toLowerCase() === candidate) {
-                return { tag: id, displayName: config.name, isTeam: false };
-            }
-        }
-
-        // Match by team name (case-insensitive)
-        for (const [id, config] of Object.entries(teams) as [string, any][]) {
-            if (config.name.toLowerCase() === candidate) {
-                return { tag: id, displayName: config.name, isTeam: true };
-            }
-        }
-    } catch {
-        // Settings unreadable — can't validate
     }
     return null;
 }
@@ -95,81 +82,60 @@ export function resolveAgentTag(candidateTag: string, settingsFile: string): Age
 /**
  * Process an incoming message for default-agent logic.
  *
- * - If the message starts with `@tag`, validate the tag and store it as default.
- *   Returns the original message unchanged plus a switch confirmation message.
- * - If the message is just `@tag` with no body, switches the default and returns
- *   null message to indicate no message should be queued.
- * - If the message has no `@tag` but a default is stored, prepends the default tag.
- * - Otherwise returns the message unchanged.
+ * - If the message starts with `@tag`, validate and store as default.
+ * - If the message is just `@tag` with no body, switch without queuing.
+ * - `@default` clears the sticky default.
+ * - Messages without `@` get the stored default prepended.
  */
 export function applyDefaultAgent(
     chatKey: string,
     messageText: string,
     settingsFile: string,
 ): { message: string | null; switchNotification: string | null } {
-    // Match @tag with optional space+body (handles both "@coder fix bug" and "@coder")
     const atMatch = messageText.match(/^@(\S+)(?:\s+([\s\S]*))?$/);
 
     if (atMatch) {
         const candidateTag = atMatch[1];
         const body = atMatch[2]?.trim() || '';
 
-        // Special case: "@default" clears the sticky default
+        // "@default" clears the sticky default
         if (candidateTag.toLowerCase() === 'default') {
-            const had = defaultAgentPerChat.has(chatKey);
-            defaultAgentPerChat.delete(chatKey);
-            saveDefaults();
-            if (had) {
-                return { message: null, switchNotification: 'Cleared default agent. Messages will use default routing.' };
-            }
-            return { message: null, switchNotification: 'No default agent was set.' };
+            const defaults = getDefaults(settingsFile);
+            const had = chatKey in defaults;
+            if (had) deleteDefault(settingsFile, chatKey);
+            return {
+                message: null,
+                switchNotification: had
+                    ? 'Cleared default agent. Messages will use default routing.'
+                    : 'No default agent was set.',
+            };
         }
 
         const match = resolveAgentTag(candidateTag, settingsFile);
         if (match) {
-            const previous = defaultAgentPerChat.get(chatKey);
-            defaultAgentPerChat.set(chatKey, match.tag);
-            saveDefaults();
-
-            // Only notify if the default actually changed
+            const previous = getDefaults(settingsFile)[chatKey];
             const switched = previous !== match.tag;
+            if (switched) saveDefault(settingsFile, chatKey, match.tag);
+
             const kind = match.isTeam ? 'team' : 'agent';
             const notification = switched
                 ? `Switched to ${kind} @${match.tag} (${match.displayName}). Future messages will be routed here automatically. Send @default to clear.`
                 : null;
 
             if (!body) {
-                // Tag-only message like "@coder" — just switch, don't queue a message
                 return { message: null, switchNotification: notification };
             }
-
-            // Pass through the original message (server will also parse the @tag)
             return { message: messageText, switchNotification: notification };
         }
-        // Unrecognized @tag — pass through as-is, don't touch default
+        // Unrecognized @tag — pass through as-is
         return { message: messageText, switchNotification: null };
     }
 
     // No @-prefix — apply stored default if any
-    const storedDefault = defaultAgentPerChat.get(chatKey);
+    const storedDefault = getDefaults(settingsFile)[chatKey];
     if (storedDefault) {
         return { message: `@${storedDefault} ${messageText}`, switchNotification: null };
     }
 
     return { message: messageText, switchNotification: null };
-}
-
-/**
- * Get the current default agent for a chat, or null if none set.
- */
-export function getDefaultAgent(chatKey: string): string | null {
-    return defaultAgentPerChat.get(chatKey) ?? null;
-}
-
-/**
- * Clear the default agent for a chat.
- */
-export function clearDefaultAgent(chatKey: string): void {
-    defaultAgentPerChat.delete(chatKey);
-    saveDefaults();
 }

--- a/src/channels/discord-client.ts
+++ b/src/channels/discord-client.ts
@@ -12,7 +12,7 @@ import path from 'path';
 import https from 'https';
 import http from 'http';
 import { ensureSenderPaired } from '../lib/pairing';
-import { applyDefaultAgent, initPersistence } from './default-agent';
+import { applyDefaultAgent } from './default-agent';
 
 const API_PORT = parseInt(process.env.TINYCLAW_API_PORT || '3777', 10);
 const API_BASE = `http://localhost:${API_PORT}`;
@@ -34,9 +34,6 @@ const PAIRING_FILE = path.join(TINYCLAW_HOME, 'pairing.json');
         fs.mkdirSync(dir, { recursive: true });
     }
 });
-
-// Load persisted default-agent-per-chat mappings
-initPersistence(TINYCLAW_HOME);
 
 // Validate bot token
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;

--- a/src/channels/telegram-client.ts
+++ b/src/channels/telegram-client.ts
@@ -14,7 +14,7 @@ import path from 'path';
 import https from 'https';
 import http from 'http';
 import { ensureSenderPaired } from '../lib/pairing';
-import { applyDefaultAgent, initPersistence } from './default-agent';
+import { applyDefaultAgent } from './default-agent';
 
 const API_PORT = parseInt(process.env.TINYCLAW_API_PORT || '3777', 10);
 const API_BASE = `http://localhost:${API_PORT}`;
@@ -36,9 +36,6 @@ const PAIRING_FILE = path.join(TINYCLAW_HOME, 'pairing.json');
         fs.mkdirSync(dir, { recursive: true });
     }
 });
-
-// Load persisted default-agent-per-chat mappings
-initPersistence(TINYCLAW_HOME);
 
 // Validate bot token
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;

--- a/src/channels/whatsapp-client.ts
+++ b/src/channels/whatsapp-client.ts
@@ -10,7 +10,7 @@ import qrcode from 'qrcode-terminal';
 import fs from 'fs';
 import path from 'path';
 import { ensureSenderPaired } from '../lib/pairing';
-import { applyDefaultAgent, initPersistence } from './default-agent';
+import { applyDefaultAgent } from './default-agent';
 
 const API_PORT = parseInt(process.env.TINYCLAW_API_PORT || '3777', 10);
 const API_BASE = `http://localhost:${API_PORT}`;
@@ -33,9 +33,6 @@ const PAIRING_FILE = path.join(TINYCLAW_HOME, 'pairing.json');
         fs.mkdirSync(dir, { recursive: true });
     }
 });
-
-// Load persisted default-agent-per-chat mappings
-initPersistence(TINYCLAW_HOME);
 
 interface PendingMessage {
     message: Message;


### PR DESCRIPTION
## Summary

When a user tags an agent with `@agent_id`, that agent becomes the default for the chat. Subsequent messages without an `@` prefix are automatically routed to the stored default, so users don't have to tag a specific agent every time. A system message confirms each switch.

## Changes

- Added `src/channels/default-agent.ts` — shared module that tracks per-chat default agents, validates tags against settings (agent IDs, team IDs, names), and prepends the stored default when no `@` prefix is present
- Integrated `applyDefaultAgent()` into Telegram, Discord, and WhatsApp clients, right before messages are queued to the API
- Switch confirmation sent back to the user only when the default actually changes

## Type of Change

- [x] New feature

## Testing

- Verified the project builds cleanly with `npm run build:main`
- Logic is client-side only; server-side routing is unchanged and continues to work as before

## Checklist

- [x] I have tested these changes locally
- [x] My changes don't introduce new warnings or errors
- [x] I have updated documentation if needed