### PR TITLE
feat: add custom provider support and auth token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - ✅ **Multi-channel** - Discord, WhatsApp, and Telegram
 - ✅ **Web portal (TinyOffice)** - Browser-based dashboard for chat, agents, teams, tasks, logs, and settings
 - ✅ **Team Observation** - You can observe agent teams conversations via `tinyclaw team visualize`
-- ✅ **Multiple AI providers** - Anthropic Claude and OpenAI Codex using existing subscriptions without breaking ToS
+- ✅ **Multiple AI providers** - Anthropic Claude, OpenAI Codex, and custom providers (any OpenAI/Anthropic-compatible endpoint)
 - ✅ **Parallel processing** - Agents process messages concurrently
 - ✅ **Live TUI dashboard** - Real-time team visualizer for monitoring agent chains
 - ✅ **Persistent sessions** - Conversation context maintained across restarts
@@ -88,7 +88,7 @@ The setup wizard will guide you through:
 2. **Bot tokens** - Enter tokens for enabled channels
 3. **Workspace setup** - Name your workspace directory
 4. **Default agent** - Configure your main AI assistant
-5. **AI provider** - Select Anthropic (Claude) or OpenAI
+5. **AI provider** - Select Anthropic (Claude), OpenAI, or a custom provider
 6. **Model selection** - Choose model (e.g., Sonnet, Opus, GPT-5.3)
 7. **Heartbeat interval** - Set proactive check-in frequency
 
@@ -213,6 +213,16 @@ Commands work with `tinyclaw` (if CLI installed) or `./tinyclaw.sh` (direct scri
 | `model [name]`                    | Show or switch AI model; propagates to matching agents   | `tinyclaw model opus`                            |
 | `reset`                           | Reset all conversations                                  | `tinyclaw reset`                                 |
 | `channels reset <channel>`        | Reset channel authentication                             | `tinyclaw channels reset whatsapp`               |
+
+### Custom Provider Commands
+
+| Command                    | Description                           | Example                            |
+| -------------------------- | ------------------------------------- | ---------------------------------- |
+| `provider list`            | List all custom providers             | `tinyclaw provider list`           |
+| `provider add`             | Add a new custom provider             | `tinyclaw provider add`            |
+| `provider remove <id>`     | Remove a custom provider              | `tinyclaw provider remove proxy`   |
+
+Custom providers let you use any OpenAI or Anthropic-compatible API endpoint with the existing CLI harnesses. See [docs/AGENTS.md](docs/AGENTS.md#custom-providers) for details.
 
 ### Pairing Commands
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -254,7 +254,7 @@ Edit `.tinyclaw/settings.json`:
 | Field               | Required | Description                                                            |
 | ------------------- | -------- | ---------------------------------------------------------------------- |
 | `name`              | Yes      | Human-readable display name                                            |
-| `provider`          | Yes      | `anthropic` or `openai`                                                |
+| `provider`          | Yes      | `anthropic`, `openai`, `opencode`, or `custom:<provider_id>`           |
 | `model`             | Yes      | Model identifier (e.g., `sonnet`, `opus`, `gpt-5.3-codex`)             |
 | `working_directory` | Yes      | Directory where agent operates (auto-set to `<workspace>/<agent_id>/`) |
 | `system_prompt`     | No       | Inline system prompt text                                              |
@@ -401,6 +401,14 @@ Use different AI providers for different tasks:
 
 ```json
 {
+  "custom_providers": {
+    "openrouter": {
+      "name": "OpenRouter",
+      "harness": "claude",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key": "sk-or-..."
+    }
+  },
   "agents": {
     "quick": {
       "provider": "anthropic",
@@ -416,6 +424,11 @@ Use different AI providers for different tasks:
       "provider": "openai",
       "model": "gpt-5.3-codex",
       "system_prompt": "Code generation specialist."
+    },
+    "proxy-agent": {
+      "provider": "custom:openrouter",
+      "model": "claude-sonnet-4-5",
+      "system_prompt": "Uses a custom API endpoint."
     }
   }
 }
@@ -591,6 +604,100 @@ interface ResponseData {
 ```
 
 State is managed by the CLI itself (claude or codex) through the `-c` flag and working directory isolation.
+
+## Custom Providers
+
+Custom providers let you use any OpenAI or Anthropic-compatible API endpoint (e.g., proxy servers, self-hosted models, OpenRouter) with the existing CLI harnesses.
+
+### Configuration
+
+Custom providers are defined in `.tinyclaw/settings.json`:
+
+```json
+{
+  "custom_providers": {
+    "my-proxy": {
+      "name": "My Proxy",
+      "harness": "claude",
+      "base_url": "https://proxy.example.com/v1",
+      "api_key": "sk-...",
+      "model": "claude-sonnet-4-5"
+    }
+  }
+}
+```
+
+| Field      | Required | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `name`     | Yes      | Human-readable display name                          |
+| `harness`  | Yes      | Which CLI to use: `claude` or `codex`                |
+| `base_url` | Yes      | API endpoint URL                                     |
+| `api_key`  | Yes      | API key for authentication                           |
+| `model`    | No       | Default model name to pass to the CLI                |
+
+### Managing Custom Providers
+
+**CLI:**
+
+```bash
+tinyclaw provider list                 # List custom providers
+tinyclaw provider add                  # Add interactively
+tinyclaw provider remove my-proxy      # Remove a custom provider
+```
+
+**API:**
+
+```bash
+# List
+curl http://localhost:3777/api/custom-providers
+
+# Create/update
+curl -X PUT http://localhost:3777/api/custom-providers/my-proxy \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"My Proxy","harness":"claude","base_url":"https://proxy.example.com/v1","api_key":"sk-...","model":"claude-sonnet-4-5"}'
+
+# Delete
+curl -X DELETE http://localhost:3777/api/custom-providers/my-proxy
+```
+
+### Assigning to Agents
+
+Use the `custom:<provider_id>` prefix as the agent's provider:
+
+```bash
+# When adding a new agent (option 4 in provider selection)
+tinyclaw agent add
+
+# Switch an existing agent
+tinyclaw agent provider coder custom:my-proxy
+tinyclaw agent provider coder custom:my-proxy --model gpt-4o
+```
+
+Or edit settings.json directly:
+
+```json
+{
+  "agents": {
+    "coder": {
+      "name": "Code Assistant",
+      "provider": "custom:my-proxy",
+      "model": "claude-sonnet-4-5",
+      "working_directory": "/Users/me/workspace/coder"
+    }
+  }
+}
+```
+
+### How It Works
+
+When an agent with `provider: "custom:<id>"` is invoked:
+
+1. The custom provider config is looked up from `settings.custom_providers`
+2. The `harness` field determines which CLI to run (`claude` or `codex`)
+3. Environment variables are set based on the harness:
+   - **claude harness**: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY=""`
+   - **codex harness**: `OPENAI_API_KEY`, `OPENAI_BASE_URL`
+4. The CLI is invoked with the model name passed through (no alias resolution)
 
 ## Teams
 

--- a/lib/agents.sh
+++ b/lib/agents.sh
@@ -150,16 +150,71 @@ agent_add() {
     echo "  1) Anthropic (Claude)"
     echo "  2) OpenAI (Codex)"
     echo "  3) OpenCode"
-    read -rp "Choose [1-3, default: 1]: " AGENT_PROVIDER_CHOICE
+    echo "  4) Custom Provider"
+    read -rp "Choose [1-4, default: 1]: " AGENT_PROVIDER_CHOICE
     case "$AGENT_PROVIDER_CHOICE" in
         2) AGENT_PROVIDER="openai" ;;
         3) AGENT_PROVIDER="opencode" ;;
+        4)
+            # List available custom providers
+            local custom_ids
+            custom_ids=$(jq -r '(.custom_providers // {}) | keys[]' "$SETTINGS_FILE" 2>/dev/null)
+            if [ -z "$custom_ids" ]; then
+                echo ""
+                echo -e "${YELLOW}No custom providers configured.${NC}"
+                echo "Add one first via the API or settings.json (custom_providers section)."
+                echo ""
+                echo "Example in settings.json:"
+                echo '  "custom_providers": {'
+                echo '    "my-proxy": {'
+                echo '      "name": "My Proxy",'
+                echo '      "harness": "claude",'
+                echo '      "base_url": "https://proxy.example.com/v1",'
+                echo '      "api_key": "sk-...",'
+                echo '      "model": "claude-sonnet-4-5"'
+                echo '    }'
+                echo '  }'
+                exit 1
+            fi
+            echo ""
+            echo "Available custom providers:"
+            local idx=1
+            local provider_list=()
+            while IFS= read -r pid; do
+                local pname
+                pname=$(jq -r "(.custom_providers // {}).\"${pid}\".name // \"${pid}\"" "$SETTINGS_FILE" 2>/dev/null)
+                local pharness
+                pharness=$(jq -r "(.custom_providers // {}).\"${pid}\".harness" "$SETTINGS_FILE" 2>/dev/null)
+                echo "  ${idx}) ${pname} (${pid}) [harness: ${pharness}]"
+                provider_list+=("$pid")
+                idx=$((idx + 1))
+            done <<< "$custom_ids"
+            read -rp "Choose [1-$((idx - 1))]: " CUSTOM_CHOICE
+            CUSTOM_CHOICE=$((CUSTOM_CHOICE - 1))
+            if [ "$CUSTOM_CHOICE" -lt 0 ] || [ "$CUSTOM_CHOICE" -ge "${#provider_list[@]}" ]; then
+                echo -e "${RED}Invalid selection${NC}"
+                exit 1
+            fi
+            AGENT_PROVIDER="custom:${provider_list[$CUSTOM_CHOICE]}"
+            ;;
         *) AGENT_PROVIDER="anthropic" ;;
     esac
 
-    # Model
+    # Model — skip for custom providers (model comes from the provider config)
     echo ""
-    if [ "$AGENT_PROVIDER" = "anthropic" ]; then
+    if [[ "$AGENT_PROVIDER" == custom:* ]]; then
+        local custom_id="${AGENT_PROVIDER#custom:}"
+        AGENT_MODEL=$(jq -r "(.custom_providers // {}).\"${custom_id}\".model // \"\"" "$SETTINGS_FILE" 2>/dev/null)
+        if [ -z "$AGENT_MODEL" ]; then
+            read -rp "Enter model name for this custom provider: " AGENT_MODEL
+        else
+            echo "Model (from custom provider): $AGENT_MODEL"
+            read -rp "Override model? [enter to keep '$AGENT_MODEL']: " MODEL_OVERRIDE
+            if [ -n "$MODEL_OVERRIDE" ]; then
+                AGENT_MODEL="$MODEL_OVERRIDE"
+            fi
+        fi
+    elif [ "$AGENT_PROVIDER" = "anthropic" ]; then
         echo "Model:"
         echo "  1) Sonnet (fast)"
         echo "  2) Opus (smartest)"
@@ -517,8 +572,22 @@ agent_provider() {
                 echo "Use 'tinyclaw agent provider ${agent_id} openai --model {gpt-5.3-codex|gpt-5.2}' to also set the model."
             fi
             ;;
+        custom:*)
+            local custom_provider_value="$provider_arg"
+            if [ -n "$model_arg" ]; then
+                jq --arg id "$agent_id" --arg prov "$custom_provider_value" --arg model "$model_arg" \
+                    '.agents[$id].provider = $prov | .agents[$id].model = $model' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to custom provider '${custom_provider_value}' with model: ${model_arg}${NC}"
+            else
+                jq --arg id "$agent_id" --arg prov "$custom_provider_value" \
+                    '.agents[$id].provider = $prov' \
+                    "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                echo -e "${GREEN}✓ Agent '${agent_id}' switched to custom provider '${custom_provider_value}'${NC}"
+            fi
+            ;;
         *)
-            echo "Usage: tinyclaw agent provider <agent_id> {anthropic|openai} [--model MODEL_NAME]"
+            echo "Usage: tinyclaw agent provider <agent_id> {anthropic|openai|custom:<id>} [--model MODEL_NAME]"
             echo ""
             echo "Examples:"
             echo "  tinyclaw agent provider coder                                    # Show current provider/model"
@@ -526,6 +595,8 @@ agent_provider() {
             echo "  tinyclaw agent provider coder openai                              # Switch to OpenAI"
             echo "  tinyclaw agent provider coder anthropic --model opus              # Switch to Anthropic Opus"
             echo "  tinyclaw agent provider coder openai --model gpt-5.3-codex        # Switch to OpenAI GPT-5.3 Codex"
+            echo "  tinyclaw agent provider coder custom:my-proxy                     # Switch to custom provider"
+            echo "  tinyclaw agent provider coder custom:my-proxy --model gpt-4o      # Switch with model override"
             exit 1
             ;;
     esac
@@ -602,4 +673,185 @@ agent_reset_multiple() {
     if [ "$has_error" -eq 1 ]; then
         exit 1
     fi
+}
+
+# ── Custom Provider Management ────────────────────────────────────────────────
+
+# List all custom providers
+custom_provider_list() {
+    if [ ! -f "$SETTINGS_FILE" ]; then
+        echo -e "${RED}No settings file found. Run setup first.${NC}"
+        exit 1
+    fi
+
+    local count
+    count=$(jq -r '(.custom_providers // {}) | length' "$SETTINGS_FILE" 2>/dev/null)
+
+    if [ "$count" = "0" ] || [ -z "$count" ]; then
+        echo -e "${YELLOW}No custom providers configured.${NC}"
+        echo ""
+        echo "Add one with:"
+        echo -e "  ${GREEN}$0 provider add${NC}"
+        return
+    fi
+
+    echo -e "${BLUE}Custom Providers${NC}"
+    echo "================"
+    echo ""
+
+    jq -r '(.custom_providers // {}) | to_entries[] | "\(.key)|\(.value.name)|\(.value.harness)|\(.value.base_url)|\(.value.model // "default")"' "$SETTINGS_FILE" 2>/dev/null | \
+    while IFS='|' read -r id name harness base_url model; do
+        echo -e "  ${GREEN}${id}${NC} - ${name}"
+        echo "    Harness:  ${harness}"
+        echo "    Base URL: ${base_url}"
+        echo "    Model:    ${model}"
+        echo ""
+    done
+
+    echo "Usage: Set an agent to use a custom provider with:"
+    echo -e "  ${GREEN}tinyclaw agent provider <agent_id> custom:<provider_id>${NC}"
+}
+
+# Add a new custom provider interactively
+custom_provider_add() {
+    if [ ! -f "$SETTINGS_FILE" ]; then
+        echo -e "${RED}No settings file found. Run setup first.${NC}"
+        exit 1
+    fi
+
+    echo -e "${BLUE}Add Custom Provider${NC}"
+    echo ""
+
+    # Provider ID
+    read -rp "Provider ID (lowercase, no spaces, e.g. 'my-proxy'): " PROVIDER_ID
+    PROVIDER_ID=$(echo "$PROVIDER_ID" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')
+    if [ -z "$PROVIDER_ID" ]; then
+        echo -e "${RED}Invalid provider ID${NC}"
+        exit 1
+    fi
+
+    # Check if exists
+    local existing
+    existing=$(jq -r "(.custom_providers // {}).\"${PROVIDER_ID}\" // empty" "$SETTINGS_FILE" 2>/dev/null)
+    if [ -n "$existing" ]; then
+        echo -e "${RED}Custom provider '${PROVIDER_ID}' already exists. Use 'provider remove ${PROVIDER_ID}' first.${NC}"
+        exit 1
+    fi
+
+    # Display name
+    read -rp "Display name (e.g. 'My OpenRouter Proxy'): " PROVIDER_NAME
+    if [ -z "$PROVIDER_NAME" ]; then
+        PROVIDER_NAME="$PROVIDER_ID"
+    fi
+
+    # Harness
+    echo ""
+    echo "Harness (which CLI to use):"
+    echo "  1) claude (Anthropic CLI)"
+    echo "  2) codex (OpenAI CLI)"
+    read -rp "Choose [1-2, default: 1]: " HARNESS_CHOICE
+    case "$HARNESS_CHOICE" in
+        2) PROVIDER_HARNESS="codex" ;;
+        *) PROVIDER_HARNESS="claude" ;;
+    esac
+
+    # Base URL
+    echo ""
+    read -rp "Base URL (e.g. 'https://proxy.example.com/v1'): " PROVIDER_BASE_URL
+    if [ -z "$PROVIDER_BASE_URL" ]; then
+        echo -e "${RED}Base URL is required${NC}"
+        exit 1
+    fi
+
+    # API Key
+    echo ""
+    read -rp "API Key: " PROVIDER_API_KEY
+    if [ -z "$PROVIDER_API_KEY" ]; then
+        echo -e "${RED}API Key is required${NC}"
+        exit 1
+    fi
+
+    # Model
+    echo ""
+    read -rp "Default model name (e.g. 'claude-sonnet-4-5', optional): " PROVIDER_MODEL
+
+    # Write to settings
+    local tmp_file="$SETTINGS_FILE.tmp"
+    local provider_json
+    if [ -n "$PROVIDER_MODEL" ]; then
+        provider_json=$(jq -n \
+            --arg name "$PROVIDER_NAME" \
+            --arg harness "$PROVIDER_HARNESS" \
+            --arg base_url "$PROVIDER_BASE_URL" \
+            --arg api_key "$PROVIDER_API_KEY" \
+            --arg model "$PROVIDER_MODEL" \
+            '{name: $name, harness: $harness, base_url: $base_url, api_key: $api_key, model: $model}')
+    else
+        provider_json=$(jq -n \
+            --arg name "$PROVIDER_NAME" \
+            --arg harness "$PROVIDER_HARNESS" \
+            --arg base_url "$PROVIDER_BASE_URL" \
+            --arg api_key "$PROVIDER_API_KEY" \
+            '{name: $name, harness: $harness, base_url: $base_url, api_key: $api_key}')
+    fi
+
+    jq --arg id "$PROVIDER_ID" --argjson prov "$provider_json" \
+        '.custom_providers //= {} | .custom_providers[$id] = $prov' \
+        "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+
+    echo ""
+    echo -e "${GREEN}✓ Custom provider '${PROVIDER_ID}' created!${NC}"
+    echo ""
+    echo -e "${BLUE}Next steps:${NC}"
+    echo "  Assign to an agent:"
+    echo -e "    ${GREEN}tinyclaw agent provider <agent_id> custom:${PROVIDER_ID}${NC}"
+    echo "  Or select it when adding a new agent:"
+    echo -e "    ${GREEN}tinyclaw agent add${NC}"
+}
+
+# Remove a custom provider
+custom_provider_remove() {
+    local provider_id="$1"
+
+    if [ ! -f "$SETTINGS_FILE" ]; then
+        echo -e "${RED}No settings file found.${NC}"
+        exit 1
+    fi
+
+    local provider_json
+    provider_json=$(jq -r "(.custom_providers // {}).\"${provider_id}\" // empty" "$SETTINGS_FILE" 2>/dev/null)
+
+    if [ -z "$provider_json" ]; then
+        echo -e "${RED}Custom provider '${provider_id}' not found.${NC}"
+        exit 1
+    fi
+
+    local provider_name
+    provider_name=$(jq -r "(.custom_providers // {}).\"${provider_id}\".name" "$SETTINGS_FILE" 2>/dev/null)
+
+    # Check if any agents use this provider
+    local using_agents
+    using_agents=$(jq -r --arg prov "custom:${provider_id}" \
+        '(.agents // {}) | to_entries[] | select(.value.provider == $prov) | .key' \
+        "$SETTINGS_FILE" 2>/dev/null)
+
+    if [ -n "$using_agents" ]; then
+        echo -e "${YELLOW}Warning: The following agents use this custom provider:${NC}"
+        echo "$using_agents" | while read -r aid; do
+            echo "  @${aid}"
+        done
+        echo ""
+        echo "These agents will fail to invoke until their provider is changed."
+    fi
+
+    read -rp "Remove custom provider '${provider_id}' (${provider_name})? [y/N]: " CONFIRM
+    if [[ ! "$CONFIRM" =~ ^[yY] ]]; then
+        echo "Cancelled."
+        return
+    fi
+
+    local tmp_file="$SETTINGS_FILE.tmp"
+    jq --arg id "$provider_id" 'del(.custom_providers[$id])' "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+
+    echo -e "${GREEN}✓ Custom provider '${provider_id}' removed.${NC}"
 }

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -1,14 +1,14 @@
 import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { AgentConfig, TeamConfig } from './types';
-import { SCRIPT_DIR, resolveClaudeModel, resolveCodexModel, resolveOpenCodeModel } from './config';
+import { AgentConfig, CustomProvider, TeamConfig } from './types';
+import { SCRIPT_DIR, resolveClaudeModel, resolveCodexModel, resolveOpenCodeModel, getSettings } from './config';
 import { log } from './logging';
 import { ensureAgentDirectory, updateAgentTeammates } from './agent';
 
-export async function runCommand(command: string, args: string[], cwd?: string): Promise<string> {
+export async function runCommand(command: string, args: string[], cwd?: string, envOverrides?: Record<string, string>): Promise<string> {
     return new Promise((resolve, reject) => {
-        const env = { ...process.env };
+        const env = { ...process.env, ...envOverrides };
         delete env.CLAUDECODE;
 
         const child = spawn(command, args, {
@@ -78,7 +78,50 @@ export async function invokeAgent(
             : path.join(workspacePath, agent.working_directory))
         : agentDir;
 
-    const provider = agent.provider || 'anthropic';
+    const rawProvider = agent.provider || 'anthropic';
+
+    // Resolve custom provider if using "custom:<id>" prefix
+    let provider = rawProvider;
+    let customProvider: CustomProvider | undefined;
+    let envOverrides: Record<string, string> = {};
+
+    if (rawProvider.startsWith('custom:')) {
+        const customId = rawProvider.slice('custom:'.length);
+        const settings = getSettings();
+        customProvider = settings.custom_providers?.[customId];
+        if (!customProvider) {
+            throw new Error(`Custom provider '${customId}' not found in settings.custom_providers`);
+        }
+        // Map harness back to built-in provider for CLI selection
+        provider = customProvider.harness === 'codex' ? 'openai' : 'anthropic';
+
+        // Build env overrides based on harness
+        if (customProvider.harness === 'claude') {
+            envOverrides = {
+                ANTHROPIC_BASE_URL: customProvider.base_url,
+                ANTHROPIC_AUTH_TOKEN: customProvider.api_key,
+                ANTHROPIC_API_KEY: '',
+            };
+        } else if (customProvider.harness === 'codex') {
+            envOverrides = {
+                OPENAI_API_KEY: customProvider.api_key,
+                OPENAI_BASE_URL: customProvider.base_url,
+            };
+        }
+
+        log('INFO', `Using custom provider '${customId}' (harness: ${customProvider.harness}, base_url: ${customProvider.base_url})`);
+    } else {
+        // For built-in providers, check if auth_token is configured in settings
+        const settings = getSettings();
+        if (provider === 'anthropic' && settings.models?.anthropic?.auth_token) {
+            envOverrides.ANTHROPIC_API_KEY = settings.models.anthropic.auth_token;
+        } else if (provider === 'openai' && settings.models?.openai?.auth_token) {
+            envOverrides.OPENAI_API_KEY = settings.models.openai.auth_token;
+        }
+    }
+
+    // Use model from custom provider if agent doesn't specify one
+    const effectiveModel = agent.model || customProvider?.model || '';
 
     if (provider === 'openai') {
         log('INFO', `Using Codex CLI (agent: ${agentId})`);
@@ -89,7 +132,7 @@ export async function invokeAgent(
             log('INFO', `🔄 Resetting Codex conversation for agent: ${agentId}`);
         }
 
-        const modelId = resolveCodexModel(agent.model);
+        const modelId = customProvider ? effectiveModel : resolveCodexModel(effectiveModel);
         const codexArgs = ['exec'];
         if (shouldResume) {
             codexArgs.push('resume', '--last');
@@ -99,7 +142,7 @@ export async function invokeAgent(
         }
         codexArgs.push('--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', '--json', message);
 
-        const codexOutput = await runCommand('codex', codexArgs, workingDir);
+        const codexOutput = await runCommand('codex', codexArgs, workingDir, envOverrides);
 
         // Parse JSONL output and extract final agent_message
         let response = '';
@@ -121,7 +164,7 @@ export async function invokeAgent(
         // Outputs JSONL with --format json; extract "text" type events for the response.
         // Model passed via --model in provider/model format (e.g. opencode/claude-sonnet-4-5).
         // Supports -c flag for conversation continuation (resumes last session).
-        const modelId = resolveOpenCodeModel(agent.model);
+        const modelId = resolveOpenCodeModel(effectiveModel);
         log('INFO', `Using OpenCode CLI (agent: ${agentId}, model: ${modelId})`);
 
         const continueConversation = !shouldReset;
@@ -139,7 +182,7 @@ export async function invokeAgent(
         }
         opencodeArgs.push(message);
 
-        const opencodeOutput = await runCommand('opencode', opencodeArgs, workingDir);
+        const opencodeOutput = await runCommand('opencode', opencodeArgs, workingDir, envOverrides);
 
         // Parse JSONL output and collect all text parts
         let response = '';
@@ -166,7 +209,7 @@ export async function invokeAgent(
             log('INFO', `🔄 Resetting conversation for agent: ${agentId}`);
         }
 
-        const modelId = resolveClaudeModel(agent.model);
+        const modelId = customProvider ? effectiveModel : resolveClaudeModel(effectiveModel);
         const claudeArgs = ['--dangerously-skip-permissions'];
         if (modelId) {
             claudeArgs.push('--model', modelId);
@@ -176,6 +219,6 @@ export async function invokeAgent(
         }
         claudeArgs.push('-p', message);
 
-        return await runCommand('claude', claudeArgs, workingDir);
+        return await runCommand('claude', claudeArgs, workingDir, envOverrides);
     }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,14 @@
+export interface CustomProvider {
+    name: string;
+    harness: 'claude' | 'codex';  // which CLI to invoke
+    base_url: string;
+    api_key: string;
+    model?: string;               // model name to pass to the CLI
+}
+
 export interface AgentConfig {
     name: string;
-    provider: string;       // 'anthropic', 'openai', or 'opencode'
+    provider: string;       // 'anthropic', 'openai', 'opencode', or 'custom:<provider_id>'
     model: string;           // e.g. 'sonnet', 'opus', 'gpt-5.3-codex'
     working_directory: string;
     system_prompt?: string;
@@ -46,15 +54,18 @@ export interface Settings {
         provider?: string; // 'anthropic', 'openai', or 'opencode'
         anthropic?: {
             model?: string;
+            auth_token?: string;
         };
         openai?: {
             model?: string;
+            auth_token?: string;
         };
         opencode?: {
             model?: string;
         };
     };
     agents?: Record<string, AgentConfig>;
+    custom_providers?: Record<string, CustomProvider>;
     teams?: Record<string, TeamConfig>;
     monitoring?: {
         heartbeat_interval?: number;

--- a/src/server/routes/agents.ts
+++ b/src/server/routes/agents.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { Hono } from 'hono';
-import { AgentConfig } from '../../lib/types';
+import { AgentConfig, CustomProvider } from '../../lib/types';
 import { SCRIPT_DIR, getSettings, getAgents } from '../../lib/config';
 import { log } from '../../lib/logging';
 import { mutateSettings } from './settings';
@@ -131,6 +131,52 @@ app.delete('/api/agents/:id', (c) => {
     }
     mutateSettings(s => { delete s.agents![agentId]; });
     log('INFO', `[API] Agent '${agentId}' deleted`);
+    return c.json({ ok: true });
+});
+
+// ── Custom Providers ─────────────────────────────────────────────────────────
+
+// GET /api/custom-providers
+app.get('/api/custom-providers', (c) => {
+    const settings = getSettings();
+    return c.json(settings.custom_providers || {});
+});
+
+// PUT /api/custom-providers/:id
+app.put('/api/custom-providers/:id', async (c) => {
+    const providerId = c.req.param('id');
+    const body = await c.req.json() as Partial<CustomProvider>;
+    if (!body.name || !body.harness || !body.base_url || !body.api_key) {
+        return c.json({ error: 'name, harness, base_url, and api_key are required' }, 400);
+    }
+    if (body.harness !== 'claude' && body.harness !== 'codex') {
+        return c.json({ error: 'harness must be "claude" or "codex"' }, 400);
+    }
+
+    const settings = mutateSettings(s => {
+        if (!s.custom_providers) s.custom_providers = {};
+        s.custom_providers[providerId] = {
+            name: body.name!,
+            harness: body.harness!,
+            base_url: body.base_url!,
+            api_key: body.api_key!,
+            ...(body.model ? { model: body.model } : {}),
+        };
+    });
+
+    log('INFO', `[API] Custom provider '${providerId}' saved`);
+    return c.json({ ok: true, provider: settings.custom_providers![providerId] });
+});
+
+// DELETE /api/custom-providers/:id
+app.delete('/api/custom-providers/:id', (c) => {
+    const providerId = c.req.param('id');
+    const settings = getSettings();
+    if (!settings.custom_providers?.[providerId]) {
+        return c.json({ error: `custom provider '${providerId}' not found` }, 404);
+    }
+    mutateSettings(s => { delete s.custom_providers![providerId]; });
+    log('INFO', `[API] Custom provider '${providerId}' deleted`);
     return c.json({ ok: true });
 });
 

--- a/tinyclaw.sh
+++ b/tinyclaw.sh
@@ -119,17 +119,37 @@ case "${1:-}" in
                 exit 1
             fi
         else
-            # Parse optional --model flag
+            # Parse optional flags: --model and --auth-token
             PROVIDER_ARG="$2"
+            PROVIDER_EXTRA_ARG="${3:-}"  # e.g. provider ID for 'remove'
             MODEL_ARG=""
-            if [ "$3" = "--model" ] && [ -n "$4" ]; then
-                MODEL_ARG="$4"
-            fi
+            AUTH_TOKEN_ARG=""
+            shift 2  # consume 'provider' and the provider name
+            while [ $# -gt 0 ]; do
+                case "$1" in
+                    --model) MODEL_ARG="$2"; shift 2 ;;
+                    --auth-token) AUTH_TOKEN_ARG="$2"; shift 2 ;;
+                    *) shift ;;
+                esac
+            done
 
             # Capture old provider before switching (for agent propagation)
             OLD_PROVIDER=$(jq -r '.models.provider // "anthropic"' "$SETTINGS_FILE" 2>/dev/null)
 
             case "$PROVIDER_ARG" in
+                list|ls)
+                    custom_provider_list
+                    ;;
+                add)
+                    custom_provider_add
+                    ;;
+                remove|rm)
+                    if [ -z "$PROVIDER_EXTRA_ARG" ]; then
+                        echo "Usage: $0 provider remove <provider_id>"
+                        exit 1
+                    fi
+                    custom_provider_remove "$PROVIDER_EXTRA_ARG"
+                    ;;
                 anthropic)
                     if [ ! -f "$SETTINGS_FILE" ]; then
                         echo -e "${RED}No settings file found. Run setup first.${NC}"
@@ -161,6 +181,14 @@ case "${1:-}" in
                         echo ""
                         echo "Use 'tinyclaw model {sonnet|opus}' to set the model."
                     fi
+
+                    # Store auth token if provided
+                    if [ -n "$AUTH_TOKEN_ARG" ]; then
+                        tmp_file="$SETTINGS_FILE.tmp"
+                        jq --arg token "$AUTH_TOKEN_ARG" '.models.anthropic.auth_token = $token' \
+                            "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                        echo -e "${GREEN}✓ Anthropic auth token saved${NC}"
+                    fi
                     ;;
                 openai)
                     if [ ! -f "$SETTINGS_FILE" ]; then
@@ -187,26 +215,42 @@ case "${1:-}" in
                             echo -e "${BLUE}  Updated $UPDATED_COUNT agent(s) from $OLD_PROVIDER to openai/$MODEL_ARG${NC}"
                         fi
                         echo ""
-                        echo "Note: Make sure you have the 'codex' CLI installed and authenticated."
+                        echo "Note: Make sure you have the 'codex' CLI installed."
                     else
                         # Set provider only (no agent propagation)
                         jq '.models.provider = "openai"' "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
                         echo -e "${GREEN}✓ Switched to OpenAI/Codex provider${NC}"
                         echo ""
                         echo "Use 'tinyclaw model {gpt-5.3-codex|gpt-5.2}' to set the model."
-                        echo "Note: Make sure you have the 'codex' CLI installed and authenticated."
+                        echo "Note: Make sure you have the 'codex' CLI installed."
+                    fi
+
+                    # Store auth token if provided
+                    if [ -n "$AUTH_TOKEN_ARG" ]; then
+                        tmp_file="$SETTINGS_FILE.tmp"
+                        jq --arg token "$AUTH_TOKEN_ARG" '.models.openai.auth_token = $token' \
+                            "$SETTINGS_FILE" > "$tmp_file" && mv "$tmp_file" "$SETTINGS_FILE"
+                        echo -e "${GREEN}✓ OpenAI auth token saved${NC}"
                     fi
                     ;;
                 *)
-                    echo "Usage: $0 provider {anthropic|openai} [--model MODEL_NAME]"
+                    echo "Usage: $0 provider {anthropic|openai|list|add|remove} [--model MODEL] [--auth-token TOKEN]"
                     echo ""
-                    echo "Examples:"
+                    echo "Global provider:"
                     echo "  $0 provider                                    # Show current provider and model"
                     echo "  $0 provider anthropic                          # Switch to Anthropic"
                     echo "  $0 provider openai                             # Switch to OpenAI"
                     echo "  $0 provider anthropic --model sonnet           # Switch to Anthropic with Sonnet"
                     echo "  $0 provider openai --model gpt-5.3-codex       # Switch to OpenAI with GPT-5.3 Codex"
-                    echo "  $0 provider openai --model gpt-4o              # Switch to OpenAI with custom model"
+                    echo ""
+                    echo "Auth tokens (skip CLI login):"
+                    echo "  $0 provider anthropic --auth-token sk-ant-...  # Set Anthropic API key"
+                    echo "  $0 provider openai --auth-token sk-...         # Set OpenAI API key"
+                    echo ""
+                    echo "Custom providers:"
+                    echo "  $0 provider list                               # List custom providers"
+                    echo "  $0 provider add                                # Add a custom provider"
+                    echo "  $0 provider remove <id>                        # Remove a custom provider"
                     exit 1
                     ;;
             esac
@@ -489,6 +533,7 @@ case "${1:-}" in
         echo "  reset <id> [id2 ...]     Reset specific agent conversation(s)"
         echo "  channels reset <channel> Reset channel auth ($local_names)"
         echo "  provider [name] [--model model]  Show or switch AI provider"
+        echo "  provider {list|add|remove}       Manage custom providers"
         echo "  model [name]             Show or switch AI model"
         echo "  agent {list|add|remove|show|reset|provider}  Manage agents"
         echo "  team {list|add|remove|show|add-agent|remove-agent|visualize}  Manage teams"


### PR DESCRIPTION
## Summary

Add custom provider system enabling users to use any OpenAI or Anthropic-compatible endpoint. Also add built-in auth token storage to eliminate need for separate CLI authentication.

## Changes

- **Custom Providers**: New CLI commands `tinyclaw provider list/add/remove` to define and manage custom API endpoints with base URL, API key, and harness selection (claude/codex)
- **Auth Token Configuration**: Store API keys via `tinyclaw provider anthropic --auth-token <key>` and `tinyclaw provider openai --auth-token <key>`
- **Agent Integration**: Agents can reference custom providers with `provider: "custom:<id>"` or CLI `tinyclaw agent provider <id> custom:<provider_id>`
- **Environment Variable Injection**: Automatically export stored auth tokens and custom provider credentials when invoking CLI commands
- **API Support**: RESTful endpoints for custom provider CRUD operations at `/api/custom-providers`
- **Interactive Setup**: `tinyclaw agent add` now includes custom provider selection as option 4
- **Documentation**: Updated README.md and docs/AGENTS.md with custom provider setup, examples, and configuration details

## Type of Change

- [x] New feature
- [x] Enhancement to existing feature
- [x] Documentation update

## Testing

- CLI commands: `tinyclaw provider list/add/remove` work interactively
- Auth token: `tinyclaw provider anthropic --auth-token sk-ant-...` stores and exports to CLI
- Agent creation: Can select custom provider during `tinyclaw agent add`
- Agent switching: `tinyclaw agent provider <id> custom:<provider_id>` updates provider
- Environment vars: Verified env vars are passed to spawned CLI commands
- API: Custom provider endpoints respond correctly

## Checklist

- [x] I have tested these changes locally
- [x] My changes don't introduce new warnings or errors
- [x] I have updated documentation if needed