### PR TITLE
fix: add delay after tmux pane creation for shell init

### DIFF
--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -151,6 +151,11 @@ start_daemon() {
         tmux select-layout -t "$TMUX_SESSION" tiled  # rebalance after each split
     done
 
+    # Wait for pane shells to finish initializing (.zshrc, conda init, nvm, etc.)
+    # Without this delay, commands sent via send-keys run in a half-initialized
+    # shell and exit silently. See: https://github.com/TinyAGI/tinyclaw/issues/156
+    sleep 2
+
     # Assign channel panes
     local pane_idx=$pane_base
     local whatsapp_pane=-1


### PR DESCRIPTION
## Summary
- Adds a 2-second delay between tmux pane creation and `send-keys` in `start_daemon` to allow shells to finish initializing (.zshrc, conda init, nvm, etc.)
- Without this delay, on systems with heavy shell startup scripts, `node` commands arrive before the shell is ready and exit silently, causing all channels to show "Not Running"

Fixes #156

## Test plan
- [ ] Run `tinyclaw start` on a macOS system with zsh + conda/nvm in .zshrc
- [ ] Verify `tinyclaw status` shows all channels as Running after startup
- [ ] Verify no regression on systems with fast shell init (bash with minimal rc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)