### PR TITLE
feat: add issue templates with triage focus

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,104 @@
+name: Bug Report
+description: Report a bug to help us triage and fix issues quickly
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and triage the issue.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug?
+      options:
+        - "Critical - System crash / data loss / security issue"
+        - "High - Core feature broken, no workaround"
+        - "Medium - Feature broken but workaround exists"
+        - "Low - Minor issue / cosmetic"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of TinyClaw is affected?
+      options:
+        - "Agent execution"
+        - "Team / multi-agent coordination"
+        - "Discord channel"
+        - "WhatsApp channel"
+        - "Telegram channel"
+        - "TinyOffice (web portal)"
+        - "Chatroom"
+        - "CLI"
+        - "Configuration / YAML"
+        - "Custom provider"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Configure agent with ...
+        2. Send message via ...
+        3. Observe error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Error Output
+      description: Paste any error messages or log output. This will be auto-formatted as code.
+      render: shell
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Paste relevant parts of your YAML config (redact secrets).
+      render: yaml
+
+  - type: input
+    id: version
+    attributes:
+      label: TinyClaw Version
+      description: Output of `tinyclaw --version` or the release you're using.
+      placeholder: e.g., 0.5.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - "macOS"
+        - "Linux"
+        - "Windows (WSL)"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other information that might help triage (screenshots, related issues, etc.).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Community
+    url: https://discord.gg/jH6AcEChuD
+    about: Ask questions and get help from the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like and why.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of TinyClaw does this relate to?
+      options:
+        - "Agent execution"
+        - "Team / multi-agent coordination"
+        - "Discord channel"
+        - "WhatsApp channel"
+        - "Telegram channel"
+        - "TinyOffice (web portal)"
+        - "Chatroom"
+        - "CLI"
+        - "Configuration / YAML"
+        - "Custom provider"
+        - "New integration"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: What problem does this solve, or what use case does it enable?
+      placeholder: I'm trying to ... but currently ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any workarounds or alternative approaches you've thought of.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or examples.


### PR DESCRIPTION
## Summary

Add issue templates for bug reports and feature requests that prioritize triage. Both templates auto-label issues with 'triage' for intake queue.

## Changes

- Bug report template with severity and component dropdowns for quick prioritization
- Feature request template with component and motivation sections
- Config to disable blank issues and link to Discord community

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement to existing feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Testing

- [x] Verified templates render correctly in GitHub issue creation UI
- [x] Confirmed auto-labeling and component dropdowns work as expected

## Checklist

- [x] I have tested these changes locally
- [x] My changes don't introduce new warnings or errors
- [x] I have updated documentation if needed