### PR TITLE
docs: update PR template to follow conventional commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,36 @@
-## Summary
+## PR Title
 
-<!-- Brief description of what this PR does and why -->
+<!--
+Use conventional commit format for the PR title:
+
+  <type>(<scope>): <short description>
+
+Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
+Scope is optional but encouraged (e.g., cli, api, config)
+
+Examples:
+  feat(cli): add --verbose flag for debug output
+  fix(api): handle null response from provider
+  docs: update README with setup instructions
+-->
+
+## Description
+
+<!--
+Explain what this PR does and why. Use conventional commit style:
+
+- Start with the imperative mood (e.g., "add", "fix", "remove", not "added", "fixes")
+- First line: concise summary of the change
+- Body: motivation, context, and details of the approach
+
+If this is a breaking change, start the body with "BREAKING CHANGE:" and explain the impact.
+-->
 
 ## Changes
 
 <!-- List the key changes made -->
 
 -
-
-## Type of Change
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Enhancement to existing feature
-- [ ] Breaking change
-- [ ] Documentation update
-- [ ] Refactor / code cleanup
 
 ## Testing
 
@@ -25,6 +40,7 @@
 
 ## Checklist
 
+- [ ] PR title follows conventional commit format (`type(scope): description`)
 - [ ] I have tested these changes locally
 - [ ] My changes don't introduce new warnings or errors
 - [ ] I have updated documentation if needed


### PR DESCRIPTION
Update the pull request template to enforce conventional commit format for titles and descriptions. This includes clear guidance on commit types, scope, imperative mood, and provides examples to help contributors write better PR titles and messages.

The template now removes generic checkboxes in favor of explicit conventional commit instructions, making it easier for contributors to follow the project's standards.

## Changes

- Add conventional commit format guidance to PR title section
- Add conventional commit description guidelines  
- Remove "Type of Change" checkboxes (now covered by commit type prefix)
- Add checklist item for verifying conventional commit title format

## Testing

Tested locally with this PR