### PR TITLE
fix(build): use tsc --build to respect dependency order in monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspaces",
+    "build": "tsc --build",
     "build:core": "npm run build -w @tinyclaw/core",
     "build:teams": "npm run build -w @tinyclaw/teams",
     "build:channels": "npm run build -w @tinyclaw/channels",


### PR DESCRIPTION
## Description

Fix build failures after the monorepo refactoring by respecting TypeScript project reference dependencies. The previous build script used `npm run build --workspaces` which runs all workspace builds in parallel, causing dependent packages to fail when `@tinyclaw/core` hadn't finished building yet.

## Changes

- Changed root build script from `npm run build --workspaces` to `tsc --build`
- This respects the project references already configured in each package's `tsconfig.json`
- Builds packages in correct dependency order: core → teams → channels/server → main

## Testing

- ✅ Build completes successfully
- ✅ All TypeScript compilation errors resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)