### PR TITLE
fix: remove stale setup-wizard.sh references

### DIFF
--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -67,7 +67,7 @@ start_daemon() {
     elif [ $load_rc -ne 0 ]; then
         echo -e "${YELLOW}No configuration found. Running setup wizard...${NC}"
         echo ""
-        "$SCRIPT_DIR/lib/setup-wizard.sh"
+        node "$SCRIPT_DIR/packages/cli/dist/setup-wizard.js"
 
         if ! load_settings; then
             echo -e "${RED}Setup failed or was cancelled${NC}"

--- a/scripts/remote-install.sh
+++ b/scripts/remote-install.sh
@@ -180,7 +180,6 @@ chmod +x bin/tinyclaw
 chmod +x tinyclaw.sh
 chmod +x scripts/install.sh
 chmod +x scripts/uninstall.sh
-chmod +x lib/setup-wizard.sh
 chmod +x lib/heartbeat-cron.sh
 chmod +x lib/update.sh
 


### PR DESCRIPTION
## Summary

Fixes #197 — first-time install fails because `lib/setup-wizard.sh` no longer exists (it was migrated to TypeScript).

- **`scripts/remote-install.sh`**: Removed `chmod +x lib/setup-wizard.sh` which broke fresh installs
- **`lib/daemon.sh`**: Updated to call `node .../setup-wizard.js` instead of the removed shell script

## Test plan

- [ ] Run `remote-install.sh` on a clean machine — step 6/6 should no longer error
- [ ] Start daemon with no `settings.json` — setup wizard should launch via Node.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)