### PR TITLE
fix(cli): convert to ESM to support @clack/prompts v1.x

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tinyclaw/cli",
   "version": "0.0.10",
+  "type": "module",
   "main": "dist/shared.js",
   "scripts": {
     "build": "tsc"

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -7,7 +7,7 @@ import {
     unwrap, cleanId, validateId, required,
     writeSettings, requireSettings, SCRIPT_DIR,
     providerOptions, promptModel, harnessOptions,
-} from './shared';
+} from './shared.ts';
 
 // --- agent add ---
 

--- a/packages/cli/src/provider.ts
+++ b/packages/cli/src/provider.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import * as p from '@clack/prompts';
-import { readSettings, writeSettings, requireSettings } from './shared';
+import { readSettings, writeSettings, requireSettings } from './shared.ts';
 
 // --- provider show ---
 

--- a/packages/cli/src/setup-wizard.ts
+++ b/packages/cli/src/setup-wizard.ts
@@ -7,7 +7,7 @@ import {
     unwrap, cleanId, validateId, required,
     writeSettings, SETTINGS_FILE, TINYCLAW_HOME, SCRIPT_DIR,
     providerOptions, promptModel,
-} from './shared';
+} from './shared.ts';
 
 const ALL_CHANNELS = ['telegram', 'discord', 'whatsapp'] as const;
 

--- a/packages/cli/src/team.ts
+++ b/packages/cli/src/team.ts
@@ -5,7 +5,7 @@ import { Settings, updateAgentTeammates } from '@tinyclaw/core';
 import {
     unwrap, cleanId, validateId,
     writeSettings, requireSettings,
-} from './shared';
+} from './shared.ts';
 
 function refreshTeamInfo(settings: Settings) {
     const agents = settings.agents || {};

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import { SCRIPT_DIR } from '@tinyclaw/core';
-import { unwrap } from './shared';
+import { unwrap } from './shared.ts';
 
 const GITHUB_REPO = 'TinyAGI/tinyclaw';
 const UPDATE_CHECK_CACHE = path.join(process.env.HOME || '~', '.tinyclaw', '.update_check');

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rewriteRelativeImportExtensions": true
   },
   "include": ["src/**/*"],
   "references": [


### PR DESCRIPTION
## Description

Fixes #205 by converting the CLI package from CommonJS to ESM, allowing use of @clack/prompts v1.x instead of the legacy v0.11.0.

## Changes

- Add `"type": "module"` to packages/cli/package.json
- Update tsconfig to use Node16 module resolution with rewriteRelativeImportExtensions
- Update relative imports to use explicit .ts extensions (automatically rewritten to .js at build time)

## Testing

- Build completes without errors
- All 7 source files compile to proper ESM output

🤖 Generated with Claude Code