### PR TITLE
feat(core): pass AGENTS.md as in-memory system prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyclaw",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyclaw",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "workspaces": [
         "packages/*"
       ],

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -4,6 +4,12 @@ import { AgentConfig, TeamConfig } from './types';
 import { SCRIPT_DIR } from './config';
 
 /**
+ * Built-in agent instructions read from the AGENTS.md template at SCRIPT_DIR.
+ * Teammate markers are replaced at runtime by buildSystemPrompt().
+ */
+export const BUILTIN_AGENT_INSTRUCTIONS = fs.readFileSync(path.join(SCRIPT_DIR, 'AGENTS.md'), 'utf8');
+
+/**
  * Recursively copy directory
  */
 export function copyDirSync(src: string, dest: string): void {
@@ -24,7 +30,8 @@ export function copyDirSync(src: string, dest: string): void {
 
 /**
  * Ensure agent directory exists with template files copied from TINYCLAW_HOME.
- * Creates directory if it doesn't exist and copies .claude/, heartbeat.md, and AGENTS.md.
+ * Creates directory if it doesn't exist. Creates an empty AGENTS.md for user customization.
+ * The built-in instructions are now passed via system prompt at invocation time.
  */
 export function ensureAgentDirectory(agentDir: string): void {
     if (fs.existsSync(agentDir)) {
@@ -47,18 +54,8 @@ export function ensureAgentDirectory(agentDir: string): void {
         fs.copyFileSync(sourceHeartbeat, targetHeartbeat);
     }
 
-    // Copy AGENTS.md
-    const sourceAgents = path.join(SCRIPT_DIR, 'AGENTS.md');
-    const targetAgents = path.join(agentDir, 'AGENTS.md');
-    if (fs.existsSync(sourceAgents)) {
-        fs.copyFileSync(sourceAgents, targetAgents);
-    }
-
-    // Copy AGENTS.md as .claude/CLAUDE.md
-    if (fs.existsSync(sourceAgents)) {
-        fs.mkdirSync(path.join(agentDir, '.claude'), { recursive: true });
-        fs.copyFileSync(sourceAgents, path.join(agentDir, '.claude', 'CLAUDE.md'));
-    }
+    // Create empty AGENTS.md for user customization
+    fs.writeFileSync(path.join(agentDir, 'AGENTS.md'), '');
 
     // Copy default skills from SCRIPT_DIR into .agents/skills
     const sourceSkills = path.join(SCRIPT_DIR, '.agents', 'skills');
@@ -83,21 +80,23 @@ export function ensureAgentDirectory(agentDir: string): void {
 }
 
 /**
- * Update the AGENTS.md in an agent's directory with current teammate info.
- * Replaces content between <!-- TEAMMATES_START --> and <!-- TEAMMATES_END --> markers.
+ * Build the full system prompt for an agent invocation.
+ * Combines built-in instructions + teammate info + user's custom AGENTS.md + config system prompt.
  */
-export function updateAgentTeammates(agentDir: string, agentId: string, agents: Record<string, AgentConfig>, teams: Record<string, TeamConfig>): void {
-    const agentsMdPath = path.join(agentDir, 'AGENTS.md');
-    if (!fs.existsSync(agentsMdPath)) return;
+export function buildSystemPrompt(
+    agentId: string,
+    agentDir: string,
+    agents: Record<string, AgentConfig>,
+    teams: Record<string, TeamConfig>,
+    configSystemPrompt?: string,
+    configPromptFile?: string
+): string {
+    let prompt = BUILTIN_AGENT_INSTRUCTIONS;
 
-    let content = fs.readFileSync(agentsMdPath, 'utf8');
+    // Build teammate block
     const startMarker = '<!-- TEAMMATES_START -->';
     const endMarker = '<!-- TEAMMATES_END -->';
-    const startIdx = content.indexOf(startMarker);
-    const endIdx = content.indexOf(endMarker);
-    if (startIdx === -1 || endIdx === -1) return;
 
-    // Find teammates from all teams this agent belongs to
     const teammates: { id: string; name: string; model: string }[] = [];
     for (const team of Object.values(teams)) {
         if (!team.agents.includes(agentId)) continue;
@@ -122,26 +121,35 @@ export function updateAgentTeammates(agentDir: string, agentId: string, agents: 
         }
     }
 
-    const newContent = content.substring(0, startIdx + startMarker.length) + block + content.substring(endIdx);
-    fs.writeFileSync(agentsMdPath, newContent);
+    // Inject teammate block into the built-in instructions
+    const startIdx = prompt.indexOf(startMarker);
+    const endIdx = prompt.indexOf(endMarker);
+    if (startIdx !== -1 && endIdx !== -1) {
+        prompt = prompt.substring(0, startIdx + startMarker.length) + block + prompt.substring(endIdx);
+    }
 
-    // Also write to .claude/CLAUDE.md
-    const claudeDir = path.join(agentDir, '.claude');
-    if (!fs.existsSync(claudeDir)) {
-        fs.mkdirSync(claudeDir, { recursive: true });
+    // Append user's custom AGENTS.md from agent workspace (if non-empty)
+    const userAgentsMd = path.join(agentDir, 'AGENTS.md');
+    if (fs.existsSync(userAgentsMd)) {
+        const userContent = fs.readFileSync(userAgentsMd, 'utf8').trim();
+        if (userContent) {
+            prompt += '\n\n' + userContent;
+        }
     }
-    const claudeMdPath = path.join(claudeDir, 'CLAUDE.md');
-    let claudeContent = '';
-    if (fs.existsSync(claudeMdPath)) {
-        claudeContent = fs.readFileSync(claudeMdPath, 'utf8');
+
+    // Append config system prompt (from settings.json)
+    if (configPromptFile) {
+        try {
+            const promptFileContent = fs.readFileSync(configPromptFile, 'utf8').trim();
+            if (promptFileContent) {
+                prompt += '\n\n' + promptFileContent;
+            }
+        } catch {
+            // Ignore missing prompt file
+        }
+    } else if (configSystemPrompt) {
+        prompt += '\n\n' + configSystemPrompt;
     }
-    const cStartIdx = claudeContent.indexOf(startMarker);
-    const cEndIdx = claudeContent.indexOf(endMarker);
-    if (cStartIdx !== -1 && cEndIdx !== -1) {
-        claudeContent = claudeContent.substring(0, cStartIdx + startMarker.length) + block + claudeContent.substring(cEndIdx);
-    } else {
-        // Append markers + block
-        claudeContent = claudeContent.trimEnd() + '\n\n' + startMarker + block + endMarker + '\n';
-    }
-    fs.writeFileSync(claudeMdPath, claudeContent);
+
+    return prompt;
 }

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { AgentConfig, CustomProvider, TeamConfig } from './types';
 import { SCRIPT_DIR, resolveClaudeModel, resolveCodexModel, resolveOpenCodeModel, getSettings } from './config';
 import { log } from './logging';
-import { ensureAgentDirectory, updateAgentTeammates } from './agent';
+import { ensureAgentDirectory, buildSystemPrompt } from './agent';
 
 export async function runCommand(command: string, args: string[], cwd?: string, envOverrides?: Record<string, string>): Promise<string> {
     return new Promise((resolve, reject) => {
@@ -68,8 +68,8 @@ export async function invokeAgent(
         log('INFO', `Initialized agent directory with config files: ${agentDir}`);
     }
 
-    // Update AGENTS.md with current teammate info
-    updateAgentTeammates(agentDir, agentId, agents, teams);
+    // Build system prompt in-memory (built-in instructions + teammates + user customization)
+    const systemPrompt = buildSystemPrompt(agentId, agentDir, agents, teams, agent.system_prompt, agent.prompt_file);
 
     // Resolve working directory
     const workingDir = agent.working_directory
@@ -138,6 +138,9 @@ export async function invokeAgent(
         if (modelId) {
             codexArgs.push('--model', modelId);
         }
+        if (systemPrompt) {
+            codexArgs.push('-c', `developer_instructions=${systemPrompt}`);
+        }
         codexArgs.push('--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', '--json', message);
 
         const codexOutput = await runCommand('codex', codexArgs, workingDir, envOverrides);
@@ -171,9 +174,24 @@ export async function invokeAgent(
             log('INFO', `Resetting OpenCode conversation for agent: ${agentId}`);
         }
 
+        // Pass system prompt via OPENCODE_CONFIG_CONTENT env var using a custom agent
+        if (systemPrompt) {
+            const configContent = JSON.stringify({
+                agent: {
+                    [agentId]: {
+                        prompt: systemPrompt
+                    }
+                }
+            });
+            envOverrides.OPENCODE_CONFIG_CONTENT = configContent;
+        }
+
         const opencodeArgs = ['run', '--format', 'json'];
         if (modelId) {
             opencodeArgs.push('--model', modelId);
+        }
+        if (systemPrompt) {
+            opencodeArgs.push('--agent', agentId);
         }
         if (continueConversation) {
             opencodeArgs.push('-c');
@@ -211,6 +229,9 @@ export async function invokeAgent(
         const claudeArgs = ['--dangerously-skip-permissions'];
         if (modelId) {
             claudeArgs.push('--model', modelId);
+        }
+        if (systemPrompt) {
+            claudeArgs.push('--system-prompt', systemPrompt);
         }
         if (continueConversation) {
             claudeArgs.push('-c');

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -38,15 +38,9 @@ function provisionAgentWorkspace(agentDir: string, _agentId: string): string[] {
         steps.push('Copied heartbeat.md');
     }
 
-    const agentsMd = path.join(SCRIPT_DIR, 'AGENTS.md');
-    if (copyIfExists(agentsMd, path.join(agentDir, 'AGENTS.md'))) {
-        steps.push('Copied AGENTS.md');
-    }
-
-    if (fs.existsSync(agentsMd)) {
-        fs.copyFileSync(agentsMd, path.join(agentDir, '.claude', 'CLAUDE.md'));
-        steps.push('Copied CLAUDE.md to .claude/');
-    }
+    // Create empty AGENTS.md for user customization (built-in instructions are passed via system prompt)
+    fs.writeFileSync(path.join(agentDir, 'AGENTS.md'), '');
+    steps.push('Created empty AGENTS.md');
 
     // Copy default skills from SCRIPT_DIR
     const skillsSrc = path.join(SCRIPT_DIR, '.agents', 'skills');


### PR DESCRIPTION
## Description

Refactor system prompt handling to build instructions in-memory at invocation time instead of copying/updating files on disk. AGENTS.md template is now read once at startup and teammate info is injected dynamically, eliminating file I/O and stale data issues.

Passes system prompt to all three CLI providers using their native flags:
- **Claude**: `--system-prompt` flag
- **Codex**: `-c developer_instructions=...` flag  
- **OpenCode**: `OPENCODE_CONFIG_CONTENT` environment variable + `--agent` flag

## Changes

- Extract AGENTS.md as `BUILTIN_AGENT_INSTRUCTIONS` constant (read once at startup)
- Add `buildSystemPrompt()` function that injects teammate info in-memory
- Append user's custom AGENTS.md and config system prompt to built prompt
- Pass system prompt to CLI invocations with appropriate flags for each provider
- Change provisioning to create empty AGENTS.md for user customization only

## Testing

- ✅ All 3 providers tested with pirate system prompt - Claude, Codex, and OpenCode all respected the system prompt
- ✅ Teammate block correctly injected between markers
- ✅ User custom AGENTS.md appended when present
- ✅ Config system_prompt merged into final prompt

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>