### PR TITLE
fix: validate settings before stopping daemon on restart

### DIFF
--- a/lib/daemon.sh
+++ b/lib/daemon.sh
@@ -267,8 +267,54 @@ stop_daemon() {
     log "Daemon stopped"
 }
 
+# Validate settings without starting the daemon.
+# Returns 0 if ready to start, non-zero otherwise.
+# Safe to call while the daemon is running — reads only, no side effects.
+preflight_check() {
+    load_settings
+    local load_rc=$?
+
+    if [ $load_rc -eq 2 ]; then
+        local jq_err
+        jq_err=$(jq empty "$SETTINGS_FILE" 2>&1)
+        echo -e "${RED}Restart aborted: settings.json contains invalid JSON${NC}"
+        echo -e "  ${YELLOW}${jq_err}${NC}"
+        echo "  Fix manually: $SETTINGS_FILE"
+        return 1
+    elif [ $load_rc -ne 0 ]; then
+        echo -e "${RED}Restart aborted: settings.json is missing or has no configuration${NC}"
+        echo "  Run 'tinyclaw setup' to reconfigure"
+        return 1
+    fi
+
+    if [ ${#ACTIVE_CHANNELS[@]} -eq 0 ]; then
+        echo -e "${RED}Restart aborted: no channels configured in settings.json${NC}"
+        echo "  Run 'tinyclaw setup' to reconfigure"
+        return 1
+    fi
+
+    for ch in "${ACTIVE_CHANNELS[@]}"; do
+        local token_key
+        token_key="$(channel_token_key "$ch")"
+        if [ -n "$token_key" ] && [ -z "$(get_channel_token "$ch")" ]; then
+            echo -e "${RED}Restart aborted: $(channel_display "$ch") bot token is missing${NC}"
+            echo "  Run 'tinyclaw setup' to reconfigure"
+            return 1
+        fi
+    done
+
+    return 0
+}
+
 # Restart daemon safely even when called from inside TinyClaw's tmux session
 restart_daemon() {
+    # Validate settings before touching the live session.
+    # If preflight fails, the running daemon stays up and we bail out.
+    if ! preflight_check; then
+        echo -e "${YELLOW}Daemon restart cancelled — live session preserved${NC}"
+        return 1
+    fi
+
     if session_exists && [ -n "${TMUX:-}" ]; then
         local current_session
         current_session=$(tmux display-message -p '#S' 2>/dev/null || true)


### PR DESCRIPTION
## Bug

`restart_daemon()` called `stop_daemon` before verifying the new settings are valid. If `settings.json` is broken (e.g. missing `channels.enabled`), the old session was already dead and `start_daemon` failed silently — leaving nothing running.

Both restart paths were broken the same way:

**Normal (outside tmux):**
```
stop_daemon      # kills live session
sleep 2
start_daemon     # fails if settings bad → nothing running
```

**Inside tmux:**
```
nohup bash tinyclaw.sh __delayed_start &   # fire-and-forget: sleep 2; start_daemon
stop_daemon                                 # kills current session immediately
# if start_daemon fails → nothing running, no way to surface error
```

## Fix

Added a `preflight_check()` function that runs the settings validation (`load_settings` + token check + channels check) **without** starting or writing anything. It is called at the top of `restart_daemon` before any stop action. If it fails, the restart is aborted with a clear error message — the live session stays up.

- Invalid JSON in `settings.json`: aborts with the jq parse error and path to fix it
- Missing/empty settings: aborts with prompt to run `tinyclaw setup`
- No channels configured: aborts with prompt to run `tinyclaw setup`
- Missing bot token for a channel: aborts identifying which channel, with prompt to run `tinyclaw setup`

## Test plan

- [ ] With a valid `settings.json`, `tinyclaw restart` works as before
- [ ] With invalid JSON in `settings.json`, `tinyclaw restart` prints the parse error and exits without killing the running session
- [ ] With `channels.enabled` removed from `settings.json`, `tinyclaw restart` aborts with "no channels configured" and the daemon keeps running
- [ ] With a missing bot token, `tinyclaw restart` identifies the affected channel and aborts

🤖 Generated with [Claude Code](https://claude.com/claude-code)