### PR TITLE
fix(teams): remove chatroom fan-out to prevent agent feedback loops

### DIFF
--- a/packages/server/src/routes/chatroom.ts
+++ b/packages/server/src/routes/chatroom.ts
@@ -32,11 +32,7 @@ app.post('/api/chatroom/:teamId', async (c) => {
         return c.json({ error: 'message is required' }, 400);
     }
 
-    const id = postToChatRoom(teamId, 'user', body.message.trim(), team.agents, {
-        channel: 'chatroom',
-        sender: 'user',
-        messageId: `chatroom_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
-    });
+    const id = postToChatRoom(teamId, 'user', body.message.trim());
 
     return c.json({ ok: true, id });
 });

--- a/packages/teams/src/conversation.ts
+++ b/packages/teams/src/conversation.ts
@@ -91,8 +91,6 @@ export function postToChatRoom(
     teamId: string,
     fromAgent: string,
     message: string,
-    teamAgents: string[],
-    originalData: { channel: string; sender: string; senderId?: string | null; messageId: string }
 ): number {
     const id = insertChatMessage(teamId, fromAgent, message);
     // Chat room messages are stored as history only — NOT enqueued as active messages for teammates.
@@ -212,9 +210,7 @@ export async function handleTeamResponse(params: {
         log('INFO', `Chat room broadcasts from @${agentId}: ${chatRoomMsgs.map(m => `#${m.teamId}`).join(', ')}`);
     }
     for (const crMsg of chatRoomMsgs) {
-        postToChatRoom(crMsg.teamId, agentId, crMsg.message, teams[crMsg.teamId].agents, {
-            channel, sender, senderId: data.senderId, messageId,
-        });
+        postToChatRoom(crMsg.teamId, agentId, crMsg.message);
     }
 
     const teamContext = resolveTeamContext(agentId, isTeamRouted, data, teams);


### PR DESCRIPTION
## Problem

Every `[#team: ...]` post was fanned out to all teammates as a full queue message, triggering a new Claude invocation per agent. When agents responded with their own `[#team: ...]` posts, this created an exponential feedback loop.

**Real-world impact:** In a 4-agent crew, a single chatroom post triggered 3 invocations. Each agent's response triggered 2 more. Within an hour of the crew team going live, this loop exhausted a 5-hour Anthropic API token limit entirely.

## Root cause

`postToChatRoom()` in `packages/teams/src/conversation.ts` enqueued the chat message for every teammate via `enqueueMessage()`. Agents processed these as regular tasks and often responded with another `[#crew: ...]` post, which triggered the next round.

## Fix

Chat room messages are now **stored as history only** — `insertChatMessage()` still runs (history is preserved), but `enqueueMessage()` fan-out is removed entirely.

Agents already receive recent chat room history as passive context when invoked for real tasks. This preserves team coordination without the runaway invocation cost.

## Trade-off

Agents no longer get a push notification for every chatroom post. They see chat history on their next invocation instead. For the intended use case (status broadcasts, findings, flags) this is the correct behavior — chatroom posts are not meant to demand immediate responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)