### PR TITLE
fix(core): suppress empty responses to prevent (Silent) channel messages

### DIFF
--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -76,6 +76,12 @@ export async function streamResponse(response: string, options: {
     });
     const { message: responseMessage, files: allFiles } = handleLongResponse(hookedResponse, outboundFiles);
 
+    // Skip queuing empty responses — they produce "(Silent)" messages in Telegram/WhatsApp
+    if (!responseMessage.trim() && allFiles.length === 0) {
+        log('DEBUG', `Empty response suppressed [${options.channel}] ${options.sender} via agent:${options.agentId}`);
+        return;
+    }
+
     enqueueResponse({
         channel: options.channel,
         sender: options.sender,


### PR DESCRIPTION
## Problem

When an agent returns an empty string (e.g. when intentionally ignoring a read-only crew chat message), `streamResponse()` was still calling `enqueueResponse()` with an empty message. Telegram delivers empty messages as **(Silent)**, which shows up as a notification with no content — confusing and noisy for users.

## Fix

Added a guard in `streamResponse()` before `enqueueResponse()`:

```ts
if (!responseMessage.trim() && allFiles.length === 0) {
    log('DEBUG', `Empty response suppressed...`);
    return;
}
```

Empty responses (no text, no files) are now dropped silently at the pipeline level rather than reaching the channel client.

## Related

Companion to #220 (chatroom fan-out loop fix). Both issues were discovered together when agents in a crew team began flooding a user's Telegram with status updates and silent messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)