### PR TITLE
feat: add Novita AI as a built-in LLM provider

### DIFF
--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -334,6 +334,7 @@ function agentProvider(agentId: string, providerArg?: string, flag?: string, mod
         case 'anthropic':
         case 'openai':
         case 'opencode':
+        case 'novita':
             agent.provider = providerArg;
             if (model) agent.model = model;
             break;
@@ -342,7 +343,7 @@ function agentProvider(agentId: string, providerArg?: string, flag?: string, mod
                 agent.provider = providerArg;
                 if (model) agent.model = model;
             } else {
-                p.log.error('Usage: tinyagi agent provider <agent_id> {anthropic|openai|opencode|custom:<id>} [--model MODEL]');
+                p.log.error('Usage: tinyagi agent provider <agent_id> {anthropic|openai|opencode|novita|custom:<id>} [--model MODEL]');
                 process.exit(1);
             }
     }

--- a/packages/cli/src/provider.ts
+++ b/packages/cli/src/provider.ts
@@ -7,7 +7,11 @@ import { readSettings, writeSettings, requireSettings } from './shared.ts';
 function providerShow() {
     const settings = requireSettings();
     const provider = settings.models?.provider || 'anthropic';
-    const modelSection = provider === 'openai' ? settings.models?.openai : settings.models?.anthropic;
+    const modelSection = provider === 'openai'
+        ? settings.models?.openai
+        : provider === 'novita'
+            ? settings.models?.novita
+            : settings.models?.anthropic;
     const model = modelSection?.model || '';
 
     if (model) {
@@ -43,8 +47,8 @@ function providerSet(providerName: string, args: string[]) {
         }
     }
 
-    if (providerName !== 'anthropic' && providerName !== 'openai') {
-        p.log.error('Usage: provider {anthropic|openai} [--model MODEL] [--auth-token TOKEN]');
+    if (providerName !== 'anthropic' && providerName !== 'openai' && providerName !== 'novita') {
+        p.log.error('Usage: provider {anthropic|openai|novita} [--model MODEL] [--auth-token TOKEN]');
         process.exit(1);
     }
 
@@ -68,14 +72,20 @@ function providerSet(providerName: string, args: string[]) {
             }
         }
 
-        p.log.success(`Switched to ${providerName === 'anthropic' ? 'Anthropic' : 'OpenAI/Codex'} provider with model: ${modelArg}`);
+        const providerLabel = providerName === 'anthropic' ? 'Anthropic' : providerName === 'novita' ? 'Novita AI' : 'OpenAI/Codex';
+        p.log.success(`Switched to ${providerLabel} provider with model: ${modelArg}`);
         if (updatedCount > 0) {
             p.log.message(`  Updated ${updatedCount} agent(s) from ${oldProvider} to ${providerName}/${modelArg}`);
         }
     } else {
-        p.log.success(`Switched to ${providerName === 'anthropic' ? 'Anthropic' : 'OpenAI/Codex'} provider`);
+        const providerLabel = providerName === 'anthropic' ? 'Anthropic' : providerName === 'novita' ? 'Novita AI' : 'OpenAI/Codex';
+        p.log.success(`Switched to ${providerLabel} provider`);
         if (providerName === 'openai') {
             p.log.message("Use 'tinyagi model {gpt-5.3-codex|gpt-5.2}' to set the model.");
+            p.log.message("Note: Make sure you have the 'codex' CLI installed.");
+        } else if (providerName === 'novita') {
+            p.log.message("Use 'tinyagi model {kimi|glm|minimax}' to set the model.");
+            p.log.message("Note: Set NOVITA_API_KEY or pass --auth-token to authenticate.");
             p.log.message("Note: Make sure you have the 'codex' CLI installed.");
         } else {
             p.log.message("Use 'tinyagi model {sonnet|opus}' to set the model.");
@@ -85,7 +95,8 @@ function providerSet(providerName: string, args: string[]) {
     if (authTokenArg) {
         if (!settings.models[providerName]) settings.models[providerName] = {};
         (settings.models as any)[providerName].auth_token = authTokenArg;
-        p.log.success(`${providerName === 'anthropic' ? 'Anthropic' : 'OpenAI'} auth token saved`);
+        const providerLabel = providerName === 'anthropic' ? 'Anthropic' : providerName === 'novita' ? 'Novita AI' : 'OpenAI';
+        p.log.success(`${providerLabel} auth token saved`);
     }
 
     writeSettings(settings);
@@ -96,7 +107,11 @@ function providerSet(providerName: string, args: string[]) {
 function modelShow() {
     const settings = requireSettings();
     const provider = settings.models?.provider || 'anthropic';
-    const modelSection = provider === 'openai' ? settings.models?.openai : settings.models?.anthropic;
+    const modelSection = provider === 'openai'
+        ? settings.models?.openai
+        : provider === 'novita'
+            ? settings.models?.novita
+            : settings.models?.anthropic;
     const model = modelSection?.model || '';
 
     if (model) {
@@ -122,20 +137,23 @@ function modelShow() {
 function modelSet(modelName: string) {
     const settings = requireSettings();
 
-    // Determine provider from model name
     const anthropicModels = ['sonnet', 'opus'];
     const openaiModels = ['gpt-5.2', 'gpt-5.3-codex'];
+    const novitaModels = ['kimi', 'glm', 'minimax', 'moonshotai/kimi-k2.5', 'zai-org/glm-5', 'minimax/minimax-m2.5'];
 
     let targetProvider: string;
     if (anthropicModels.includes(modelName)) {
         targetProvider = 'anthropic';
     } else if (openaiModels.includes(modelName)) {
         targetProvider = 'openai';
+    } else if (novitaModels.includes(modelName)) {
+        targetProvider = 'novita';
     } else {
-        p.log.error('Usage: model {sonnet|opus|gpt-5.2|gpt-5.3-codex}');
+        p.log.error('Usage: model {sonnet|opus|gpt-5.2|gpt-5.3-codex|kimi|glm|minimax}');
         p.log.message('');
         p.log.message('Anthropic models: sonnet, opus');
         p.log.message('OpenAI models: gpt-5.2, gpt-5.3-codex');
+        p.log.message('Novita AI models: kimi, glm, minimax');
         process.exit(1);
     }
 
@@ -176,6 +194,7 @@ switch (command) {
         break;
     case 'anthropic':
     case 'openai':
+    case 'novita':
         providerSet(command, args);
         break;
     case 'model':
@@ -187,7 +206,7 @@ switch (command) {
         break;
     default:
         p.log.error(`Unknown provider command: ${command}`);
-        p.log.message('Usage: provider {show|anthropic|openai} [--model MODEL] [--auth-token TOKEN]');
+        p.log.message('Usage: provider {show|anthropic|openai|novita} [--model MODEL] [--auth-token TOKEN]');
         p.log.message('       provider model [name]');
         process.exit(1);
 }

--- a/packages/cli/src/shared.ts
+++ b/packages/cli/src/shared.ts
@@ -96,11 +96,21 @@ export function providerOptions(includeCustom = false): ProviderOption[] {
         { value: 'anthropic', label: 'Anthropic (Claude)', hint: 'recommended' },
         { value: 'openai', label: 'OpenAI (Codex/GPT)' },
         { value: 'opencode', label: 'OpenCode' },
+        { value: 'novita', label: 'Novita AI', hint: 'kimi-k2.5, glm-5, minimax-m2.5' },
     ];
     if (includeCustom) {
         opts.push({ value: 'custom', label: 'Custom Provider' });
     }
     return opts;
+}
+
+export function novitaModelOptions(): ProviderOption[] {
+    return [
+        { value: 'moonshotai/kimi-k2.5', label: 'kimi-k2.5', hint: 'recommended, 262k context' },
+        { value: 'zai-org/glm-5', label: 'glm-5', hint: '202k context' },
+        { value: 'minimax/minimax-m2.5', label: 'minimax-m2.5', hint: '204k context' },
+        { value: '__custom__', label: 'Custom', hint: 'enter model name' },
+    ];
 }
 
 export function anthropicModelOptions(): ProviderOption[] {
@@ -158,6 +168,9 @@ export async function promptModel(provider: string): Promise<string> {
     } else if (provider === 'opencode') {
         options = opencodeModelOptions();
         customHint = 'Enter model name (e.g. provider/model)';
+    } else if (provider === 'novita') {
+        options = novitaModelOptions();
+        customHint = 'Enter model name (e.g. moonshotai/kimi-k2.5)';
     } else {
         options = openaiModelOptions();
     }

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -4,6 +4,7 @@ import { AgentAdapter } from './types';
 import { claudeAdapter } from './claude';
 import { codexAdapter } from './codex';
 import { opencodeAdapter } from './opencode';
+import { novitaAdapter } from './novita';
 
 /** Provider → adapter registry, built automatically from adapter declarations. */
 const registry = new Map<string, AgentAdapter>();
@@ -18,6 +19,7 @@ function register(adapter: AgentAdapter) {
 register(claudeAdapter);
 register(codexAdapter);
 register(opencodeAdapter);
+register(novitaAdapter);
 
 export function getAdapter(provider: string): AgentAdapter | undefined {
     return registry.get(provider);

--- a/packages/core/src/adapters/novita.ts
+++ b/packages/core/src/adapters/novita.ts
@@ -1,0 +1,70 @@
+import { AgentAdapter, InvokeOptions } from './types';
+import { runCommand, runCommandStreaming } from '../invoke';
+import { log } from '../logging';
+
+/**
+ * Extract displayable text from a Codex JSONL event.
+ */
+function extractEventText(json: any): string | null {
+    if (json.type === 'item.completed' && json.item?.type === 'agent_message') {
+        return json.item.text || null;
+    }
+    return null;
+}
+
+/**
+ * Novita AI adapter — uses the OpenAI-compatible endpoint (https://api.novita.ai/openai)
+ * via the `codex` CLI. Credentials are injected as OPENAI_API_KEY + OPENAI_BASE_URL
+ * env overrides by invokeAgent() in invoke.ts.
+ */
+export const novitaAdapter: AgentAdapter = {
+    providers: ['novita'],
+
+    async invoke(opts: InvokeOptions): Promise<string> {
+        const { agentId, message, workingDir, systemPrompt, model, shouldReset, envOverrides, onEvent } = opts;
+        log('DEBUG', `Using Novita AI provider (agent: ${agentId})`);
+
+        const shouldResume = !shouldReset;
+        if (shouldReset) {
+            log('INFO', `Resetting Novita conversation for agent: ${agentId}`);
+        }
+
+        const args = ['exec'];
+        if (shouldResume) args.push('resume', '--last');
+        if (model) args.push('--model', model);
+        if (systemPrompt) args.push('-c', `developer_instructions=${systemPrompt}`);
+        args.push('--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', '--json', message);
+
+        let response = '';
+
+        if (onEvent) {
+            await runCommandStreaming('codex', args, (line) => {
+                try {
+                    const json = JSON.parse(line);
+                    const text = extractEventText(json);
+                    if (text) {
+                        response = text;
+                        onEvent(text);
+                    }
+                } catch (e) {
+                    // Ignore non-JSON lines
+                }
+            }, workingDir, envOverrides);
+        } else {
+            const output = await runCommand('codex', args, workingDir, envOverrides);
+            const lines = output.trim().split('\n');
+            for (const line of lines) {
+                try {
+                    const json = JSON.parse(line);
+                    if (json.type === 'item.completed' && json.item?.type === 'agent_message') {
+                        response = json.item.text;
+                    }
+                } catch (e) {
+                    // Ignore non-JSON lines
+                }
+            }
+        }
+
+        return response || 'Sorry, I could not generate a response from Novita AI.';
+    },
+};

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -39,7 +39,10 @@ export function getSettings(): Settings {
 
         // Auto-detect provider if not specified
         if (!settings?.models?.provider) {
-            if (settings?.models?.openai) {
+            if (settings?.models?.novita) {
+                if (!settings.models) settings.models = {};
+                settings.models.provider = 'novita';
+            } else if (settings?.models?.openai) {
                 if (!settings.models) settings.models = {};
                 settings.models.provider = 'openai';
             } else if (settings?.models?.opencode) {
@@ -68,6 +71,8 @@ export function getDefaultAgentFromModels(settings: Settings): AgentConfig {
         model = settings?.models?.openai?.model || 'gpt-5.3-codex';
     } else if (provider === 'opencode') {
         model = settings?.models?.opencode?.model || 'sonnet';
+    } else if (provider === 'novita') {
+        model = settings?.models?.novita?.model || 'moonshotai/kimi-k2.5';
     } else {
         model = settings?.models?.anthropic?.model || 'sonnet';
     }
@@ -103,10 +108,6 @@ export function getTeams(settings: Settings): Record<string, TeamConfig> {
     return settings.teams || {};
 }
 
-/**
- * Resolve shorthand model aliases (e.g. 'sonnet' → 'claude-sonnet-4-6').
- * Unknown models pass through as-is to the CLI.
- */
 export function resolveModel(model: string, provider: string): string {
     return MODEL_ALIASES[provider]?.[model] || model || '';
 }

--- a/packages/core/src/invoke.ts
+++ b/packages/core/src/invoke.ts
@@ -182,14 +182,21 @@ export async function invokeAgent(
             envOverrides.ANTHROPIC_API_KEY = settings.models.anthropic.auth_token;
         } else if (provider === 'openai' && settings.models?.openai?.auth_token) {
             envOverrides.OPENAI_API_KEY = settings.models.openai.auth_token;
+        } else if (provider === 'novita') {
+            // Novita uses the OpenAI-compatible endpoint via the codex CLI
+            const apiKey = settings.models?.novita?.api_key || process.env.NOVITA_API_KEY || '';
+            if (apiKey) envOverrides.OPENAI_API_KEY = apiKey;
+            envOverrides.OPENAI_BASE_URL = 'https://api.novita.ai/openai';
+            log('INFO', `Using Novita AI provider (base_url: https://api.novita.ai/openai)`);
         }
     }
 
     // Resolve model — custom providers use their own model, otherwise resolve via aliases
     const effectiveModel = agent.model || customProvider?.model || '';
+    const modelForAlias = rawProvider === 'novita' ? 'novita' : provider;
     const model = customProvider
         ? effectiveModel
-        : resolveModel(effectiveModel, provider as 'anthropic' | 'openai' | 'opencode');
+        : resolveModel(effectiveModel, modelForAlias);
 
     // Look up the adapter
     const adapter = getAdapter(provider);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,7 +38,7 @@ export interface Settings {
         defaults?: Record<string, { agentId: string }>;
     };
     models?: {
-        provider?: string; // 'anthropic', 'openai', or 'opencode'
+        provider?: string; // 'anthropic', 'openai', 'opencode', or 'novita'
         anthropic?: {
             model?: string;
             auth_token?: string;
@@ -49,6 +49,10 @@ export interface Settings {
         };
         opencode?: {
             model?: string;
+        };
+        novita?: {
+            model?: string;
+            api_key?: string;
         };
     };
     agents?: Record<string, AgentConfig>;
@@ -92,6 +96,11 @@ export const MODEL_ALIASES: Record<string, Record<string, string>> = {
     opencode: {
         'sonnet': 'opencode/claude-sonnet-4-6',
         'opus': 'opencode/claude-opus-4-6',
+    },
+    novita: {
+        'kimi': 'moonshotai/kimi-k2.5',
+        'glm': 'zai-org/glm-5',
+        'minimax': 'minimax/minimax-m2.5',
     },
 };
 

--- a/tinyoffice/src/app/agents/page.tsx
+++ b/tinyoffice/src/app/agents/page.tsx
@@ -219,6 +219,7 @@ function AgentEditor({
                 <SelectItem value="anthropic">anthropic</SelectItem>
                 <SelectItem value="openai">openai</SelectItem>
                 <SelectItem value="opencode">opencode</SelectItem>
+                <SelectItem value="novita">novita</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -276,6 +277,7 @@ function AgentCard({
     anthropic: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
     openai: "bg-green-500/10 text-green-600 dark:text-green-400",
     opencode: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    novita: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
   };
 
   return (


### PR DESCRIPTION
## Summary

Adds [Novita AI](https://novita.ai) as a first-class provider alongside Anthropic, OpenAI, and OpenCode.

Novita exposes an OpenAI-compatible API, so this integration reuses the existing **codex harness** with a custom `OPENAI_BASE_URL`. No new CLI dependency is required.

**Supported models** (from Novita's catalog):

| Model ID | Notes |
|----------|-------|
| `moonshotai/kimi-k2.5` | Default — 262k context, function calling, vision |
| `zai-org/glm-5` | 202k context, function calling |
| `minimax/minimax-m2.5` | 204k context, function calling |

**Configuration**

```jsonc
// ~/.tinyagi/settings.json
{
  "models": {
    "provider": "novita",
    "novita": {
      "model": "moonshotai/kimi-k2.5",
      "auth_token": "<NOVITA_API_KEY>"
    }
  }
}
```

Or set the `NOVITA_API_KEY` environment variable — the provider picks it up automatically.

**CLI**

```bash
tinyagi provider novita --model moonshotai/kimi-k2.5 --auth-token <key>
```

## Changes

- `packages/core/src/types.ts` — add `novita` to `Settings.models`; add model aliases to `MODEL_ALIASES`
- `packages/core/src/config.ts` — auto-detect novita from settings; default model in `getDefaultAgentFromModels`
- `packages/core/src/invoke.ts` — inject `OPENAI_API_KEY` + `OPENAI_BASE_URL` for novita, route through codex harness
- `packages/cli/src/shared.ts` — add novita to `providerOptions()`, add `novitaModelOptions()`, wire into `promptModel()`
- `packages/cli/src/provider.ts` — accept novita in CLI dispatch; provider-appropriate hints; generic `modelSection` lookup