### PR TITLE
fix(heartbeat): honor top-level heartbeat.enabled=false setting

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,6 +58,9 @@ export interface Settings {
     monitoring?: {
         heartbeat_interval?: number;
     };
+    heartbeat?: {
+        enabled?: boolean;
+    };
 }
 
 export interface MessageData {

--- a/packages/main/src/heartbeat.ts
+++ b/packages/main/src/heartbeat.ts
@@ -18,6 +18,11 @@ function getHeartbeatInterval(): number {
     return settings?.monitoring?.heartbeat_interval ?? 3600;
 }
 
+function isHeartbeatEnabled(): boolean {
+    const settings = getSettings();
+    return settings?.heartbeat?.enabled !== false;
+}
+
 function getBaseInterval(): number {
     const defaultInterval = getHeartbeatInterval();
     const settings = getSettings();
@@ -35,6 +40,7 @@ function getBaseInterval(): number {
 }
 
 async function tick(): Promise<void> {
+    if (!isHeartbeatEnabled()) return;
     const settings = getSettings();
     const agents = getAgents(settings);
     const defaultInterval = getHeartbeatInterval();
@@ -85,6 +91,10 @@ async function tick(): Promise<void> {
 }
 
 export function startHeartbeat(): void {
+    if (!isHeartbeatEnabled()) {
+        log('INFO', 'Heartbeat disabled (heartbeat.enabled=false in settings)');
+        return;
+    }
     const interval = getBaseInterval();
     log('INFO', `Heartbeat started (interval: ${interval}s)`);
     timer = setInterval(() => { tick().catch(() => {}); }, interval * 1000);


### PR DESCRIPTION
## Description

The `Settings` type declared `heartbeat.enabled` only at the per-agent level (`AgentConfig.heartbeat.enabled`). A top-level `heartbeat.enabled` flag in `settings.json` was silently ignored, and `startHeartbeat()` was called unconditionally in `packages/main/src/index.ts:272`, so users had no way to disable the heartbeat interval globally without editing every agent entry.

This came up in practice running an 8-agent team against a single shared inference backend: every hour, all 8 heartbeats fire concurrently and serialize through the same GPU, creating a large backlog. The natural workaround — `heartbeat: { enabled: false }` at the top of `settings.json` — compiled fine (TypeScript didn't complain because the field wasn't in the type) but did nothing at runtime.

## Changes

- Add optional top-level `heartbeat?: { enabled?: boolean }` to the `Settings` interface in `packages/core/src/types.ts`
- Add `isHeartbeatEnabled()` helper in `packages/main/src/heartbeat.ts`
- Short-circuit `startHeartbeat()` when disabled, logging a clear `"Heartbeat disabled (heartbeat.enabled=false in settings)"` message instead of silently still creating the interval
- Also check in `tick()` as a safety net, so runtime config changes take effect without a daemon restart

Default behavior is unchanged — when the flag is undefined (the common case), heartbeat continues to run exactly as before. Per-agent `agent.heartbeat.enabled` remains fully supported.

## Testing

- `npm run build` — clean compile, no new warnings
- Verified locally that `heartbeat: { enabled: false }` at the top level now logs `"Heartbeat disabled"` on daemon start and the interval is never created

## Checklist

- [x] PR title follows conventional commit format
- [x] I have tested these changes locally
- [x] My changes don't introduce new warnings or errors
- [ ] I have updated documentation if needed — no existing docs mention `heartbeat.enabled`; happy to add a note to the README if you'd prefer