### PR TITLE
fix(install): add postinstall script to auto-rebuild better-sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "whatsapp": "npm run whatsapp -w @tinyagi/channels",
     "server": "npm run start -w @tinyagi/server",
     "visualize": "npm run visualize -w @tinyagi/visualizer",
-    "chatroom": "npm run chatroom -w @tinyagi/visualizer"
+    "chatroom": "npm run chatroom -w @tinyagi/visualizer",
+    "postinstall": "npm rebuild better-sqlite3 --silent 2>/dev/null || true"
   },
   "devDependencies": {
     "@types/node": "^25.2.2",


### PR DESCRIPTION
## Description

Auto-rebuild better-sqlite3 after `npm install` to eliminate the need for manual `npm rebuild better-sqlite3`.

The `better-sqlite3` package is a native C++ addon that must be compiled for the current Node.js runtime. On fresh installs, users encounter errors because the prebuilt binary doesn't match their environment. All three existing rebuild invocations in the project (CLI install/update scripts and `install.sh`) use the pattern `npm rebuild better-sqlite3 --silent 2>/dev/null || true` for graceful fallback when native build tools are absent. This change applies the same pattern as a root `postinstall` hook so the rebuild happens automatically and silently on every `npm install`.

Fixes #278

## Changes

- Add `"postinstall": "npm rebuild better-sqlite3 --silent 2>/dev/null || true"` to root `package.json`

## Testing

Tested on Windows (Node.js v24.11.1):
- Clean install: postinstall triggered, output "rebuilt dependencies successfully"
- Incremental install: works with existing `node_modules`
- Graceful fallback: `|| true` prevents install failure when rebuild fails
- Full pipeline: `npm install` → `npm run build` → zero errors
- 0 vulnerabilities

## Checklist

- [x] PR title follows conventional commit format (`type(scope): description`)
- [x] I have tested these changes locally
- [x] My changes don't introduce new warnings or errors
- [x] I have updated documentation if needed
