### PR TITLE
fix(cli): print the "New leader" note after removing a team leader

### DIFF
--- a/packages/cli/src/team.ts
+++ b/packages/cli/src/team.ts
@@ -145,10 +145,11 @@ async function teamRemoveAgent(teamId: string, agentId: string) {
     }
 
     team.agents = remaining;
+    const previousLeader = team.leader_agent;
     team.leader_agent = newLeader;
     writeSettings(settings);
 
-    p.log.success(`Removed @${agentId} from team '${teamId}'.${newLeader !== team.leader_agent ? ` New leader: @${newLeader}.` : ''}`);
+    p.log.success(`Removed @${agentId} from team '${teamId}'.${newLeader !== previousLeader ? ` New leader: @${newLeader}.` : ''}`);
 }
 
 // --- team list ---


### PR DESCRIPTION
## Problem

In `teamRemoveAgent` (`packages/cli/src/team.ts`), when the removed agent is the team leader the command prompts for a replacement, then builds the success message with an always-false condition:

```ts
team.agents = remaining;
team.leader_agent = newLeader;   // leader_agent is now === newLeader
writeSettings(settings);

p.log.success(`Removed @${agentId} from team '${teamId}'.${newLeader !== team.leader_agent ? ` New leader: @${newLeader}.` : ''}`);
```

`team.leader_agent` was just assigned `newLeader`, so `newLeader !== team.leader_agent` is structurally always `false`. The ` New leader: @<x>.` suffix therefore **never prints** — even when the removed agent was the leader and the user explicitly picked a replacement via the prompt. The function goes out of its way to detect leader removal and prompt for a new leader, which shows the note was meant to render.

## Reproduction

Team `dev` = `[alice, bob]`, leader `alice`; remove `alice`, choose `bob`:

- **Before:** `Removed @alice from team 'dev'.`
- **After:** `Removed @alice from team 'dev'. New leader: @bob.`

## Fix

Capture the previous leader before the assignment and compare against it:

```ts
team.agents = remaining;
const previousLeader = team.leader_agent;
team.leader_agent = newLeader;
writeSettings(settings);

p.log.success(`Removed @${agentId} from team '${teamId}'.${newLeader !== previousLeader ? ` New leader: @${newLeader}.` : ''}`);
```

**Severity note (being upfront):** this is a genuine always-false-condition logic bug, but its only effect is a missing informational CLI line — team state is written correctly either way. I verified the corrected ternary RED→GREEN (changed leader → note prints; unchanged → no note). The function is interactive (`@clack/prompts`), and the repo has no test harness, so there's no unit test to add.
